### PR TITLE
Barbarians

### DIFF
--- a/dist/client/camera.js
+++ b/dist/client/camera.js
@@ -251,7 +251,7 @@ class Camera {
                             }
                         }
                     }
-                    if (tile.owner) {
+                    if (tile.owner && !tile.owner.isBarbarian) {
                         const neighbors = world.getNeighbors({ x, y }, false);
                         ctx.beginPath();
                         ctx.lineWidth = margin * 2;

--- a/dist/client/camera.js
+++ b/dist/client/camera.js
@@ -120,7 +120,7 @@ class Camera {
     }
     // The `render` and `renderUnit` methods are exempt from using Coord type, as they must store the `x` and `y` variables separately.
     renderUnit(world, unit, x, y) {
-        var _a;
+        var _a, _b, _c;
         const { zoom, x: camX, y: camY, textures, ctx } = this;
         const { width, height, civs } = world;
         const UNIT_WIDTH = (74 * 0.2);
@@ -134,12 +134,12 @@ class Camera {
         if (unit.cloaked)
             ctx.globalAlpha = 0.5;
         // Unit Color Background
-        ctx.fillStyle = civs[unit.civID].color;
+        ctx.fillStyle = (_b = (_a = civs[unit.civID]) === null || _a === void 0 ? void 0 : _a.color) !== null && _b !== void 0 ? _b : (unit.isBarbarian ? '#F00' : '#333');
         ctx.beginPath();
         ctx.rect((-camX + ((x - (width / 2)) * X_TILE_SPACING) + 6.5) * zoom, (camY - (((y - (height / 2)) * TILE_HEIGHT) + (mod(x, 2) * Y_TILE_SPACING)) + 5) * zoom, UNIT_WIDTH * zoom, UNIT_RECT_HEIGHT * zoom);
         ctx.arc((-camX + ((x - (width / 2)) * X_TILE_SPACING) + 6.5 + (UNIT_WIDTH / 2)) * zoom, (camY - (((y - (height / 2)) * TILE_HEIGHT) + (mod(x, 2) * Y_TILE_SPACING)) + 5 + UNIT_RECT_HEIGHT) * zoom, (UNIT_WIDTH / 2) * zoom, 0, Math.PI);
         ctx.fill();
-        ctx.drawImage(((_a = textures.unit[unit.type]) !== null && _a !== void 0 ? _a : textures.missing), (-camX + ((x - (width / 2)) * X_TILE_SPACING) + 6.5) * zoom, (camY - (((y - (height / 2)) * TILE_HEIGHT) + (mod(x, 2) * Y_TILE_SPACING)) + 5) * zoom, UNIT_WIDTH * zoom, UNIT_HEIGHT * zoom);
+        ctx.drawImage(((_c = textures.unit[unit.type]) !== null && _c !== void 0 ? _c : textures.missing), (-camX + ((x - (width / 2)) * X_TILE_SPACING) + 6.5) * zoom, (camY - (((y - (height / 2)) * TILE_HEIGHT) + (mod(x, 2) * Y_TILE_SPACING)) + 5) * zoom, UNIT_WIDTH * zoom, UNIT_HEIGHT * zoom);
         ctx.globalAlpha = 1;
     }
     drawTileLine(x1, y1, x2, y2) {

--- a/dist/server/game/map/generator/index.js
+++ b/dist/server/game/map/generator/index.js
@@ -37,10 +37,14 @@ const MOUNTAIN = new biome_1.TileType('mountain', 5, {});
 const MOUNTAIN_SPRING = new biome_1.TileType('mountain', 5, {}, null, false, false, true);
 class PerlinWorldGenerator {
     constructor(seed, { width, height }) {
-        this.reseed(seed);
-        this.simplex = new simplex_noise_1.default(this.random.randFloat);
         this.width = width;
         this.height = height;
+        this.reseed(seed);
+    }
+    reseed(seed) {
+        this.seed = seed !== null && seed !== void 0 ? seed : Math.floor(Math.random() * 9007199254740991);
+        this.random = new random_1.Random(this.seed);
+        this.simplex = new simplex_noise_1.default(this.random.randFloat);
         // Elevation Constants - Make these configurable later
         const OCEAN_LEVEL = 45;
         const COAST_LEVEL = 55;
@@ -98,10 +102,6 @@ class PerlinWorldGenerator {
                 [MOUNTAIN_LEVEL, new biome_1.TilePool([[MOUNTAIN, 15], [MOUNTAIN_SPRING, 1]])],
             ]),
         };
-    }
-    reseed(seed) {
-        this.seed = seed !== null && seed !== void 0 ? seed : Math.floor(Math.random() * 9007199254740991);
-        this.random = new random_1.Random(this.seed);
     }
     getBiome(temp, humidity) {
         if (temp < 5)

--- a/dist/server/game/map/generator/index.js
+++ b/dist/server/game/map/generator/index.js
@@ -37,6 +37,7 @@ const MOUNTAIN = new biome_1.TileType('mountain', 5, {});
 const MOUNTAIN_SPRING = new biome_1.TileType('mountain', 5, {}, null, false, false, true);
 class PerlinWorldGenerator {
     constructor(seed, { width, height }) {
+        this.seed = seed;
         this.random = new random_1.Random(seed);
         this.simplex = new simplex_noise_1.default(this.random.randFloat);
         this.width = width;
@@ -187,7 +188,7 @@ class PerlinWorldGenerator {
             const river = new biome_1.River(x, y, this.width);
             river.generate(tileTypeMap, heightMap, RIVER);
         }
-        const map = new __1.Map(height, width);
+        const map = new __1.Map(height, width, this.seed);
         let i = 0;
         for (let y = 0; y < height; y++) {
             for (let x = 0; x < width; x++) {

--- a/dist/server/game/map/generator/index.js
+++ b/dist/server/game/map/generator/index.js
@@ -37,8 +37,7 @@ const MOUNTAIN = new biome_1.TileType('mountain', 5, {});
 const MOUNTAIN_SPRING = new biome_1.TileType('mountain', 5, {}, null, false, false, true);
 class PerlinWorldGenerator {
     constructor(seed, { width, height }) {
-        this.seed = seed;
-        this.random = new random_1.Random(seed);
+        this.reseed(seed);
         this.simplex = new simplex_noise_1.default(this.random.randFloat);
         this.width = width;
         this.height = height;
@@ -99,6 +98,10 @@ class PerlinWorldGenerator {
                 [MOUNTAIN_LEVEL, new biome_1.TilePool([[MOUNTAIN, 15], [MOUNTAIN_SPRING, 1]])],
             ]),
         };
+    }
+    reseed(seed) {
+        this.seed = seed !== null && seed !== void 0 ? seed : Math.floor(Math.random() * 9007199254740991);
+        this.random = new random_1.Random(this.seed);
     }
     getBiome(temp, humidity) {
         if (temp < 5)
@@ -200,7 +203,7 @@ class PerlinWorldGenerator {
                 i++;
             }
         }
-        console.log(`Map generation completed in ${new Date().getTime() - startTime}ms.`);
+        console.log(`Map generation completed in ${new Date().getTime() - startTime}ms with seed ${this.seed}.`);
         return map;
     }
 }

--- a/dist/server/game/map/index.js
+++ b/dist/server/game/map/index.js
@@ -384,9 +384,9 @@ class Map {
         const tile = this.getTile(coords);
         if (!this.canSettleOn(tile))
             return null;
-        const camp = new city_1.BarbarianCamp(coords);
+        const cityID = this.cities.length;
+        const camp = new city_1.BarbarianCamp(cityID, coords);
         this.cities.push(camp);
-        const cityID = this.cities.length - 1;
         this.buildImprovementAt(coords, 'barbarian_camp');
         return cityID;
     }
@@ -394,7 +394,8 @@ class Map {
         const tile = this.getTile(coords);
         if (!this.canSettleOn(tile))
             return false;
-        const city = new city_1.City(coords, name, civID);
+        const cityID = this.cities.length;
+        const city = new city_1.City(cityID, coords, name, civID);
         this.cities.push(city);
         for (const neighbor of this.getNeighborsCoords(coords)) {
             this.setTileOwner(neighbor, city, false);

--- a/dist/server/game/map/index.js
+++ b/dist/server/game/map/index.js
@@ -235,7 +235,6 @@ class Map {
         owner.addTile(coords);
     }
     getCivTile(civID, tile) {
-        return tile.getVisibleData(civID);
         if (tile.discoveredBy[civID]) {
             if (tile.visibleTo[civID]) {
                 return tile.getVisibleData(civID);

--- a/dist/server/game/map/index.js
+++ b/dist/server/game/map/index.js
@@ -387,6 +387,7 @@ class Map {
         const cityID = this.cities.length;
         const camp = new city_1.BarbarianCamp(cityID, coords);
         this.cities.push(camp);
+        this.setTileOwner(coords, camp, false);
         this.buildImprovementAt(coords, 'barbarian_camp');
         return cityID;
     }

--- a/dist/server/game/map/index.js
+++ b/dist/server/game/map/index.js
@@ -71,6 +71,9 @@ class Map {
             y: Math.floor(pos / this.width),
         };
     }
+    areValidCoords(coords) {
+        return coords.y >= 0 && coords.y < this.height;
+    }
     getUpdates() {
         return this.updates.splice(0);
     }
@@ -506,6 +509,7 @@ class Map {
                 }
             }
         });
+        this.cities.forEach(city => city.turn(world, this));
         // Traders
         const traderResets = [];
         for (let i = 0; i < this.traders.length; i++) {

--- a/dist/server/game/map/index.js
+++ b/dist/server/game/map/index.js
@@ -219,13 +219,18 @@ class Map {
             if (!overwrite)
                 return;
             (_a = tile.owner) === null || _a === void 0 ? void 0 : _a.removeTile(coords);
-            tile.setVisibility(tile.owner.civID, false);
+            if (tile.owner.civID) {
+                tile.setVisibility(tile.owner.civID, false);
+            }
         }
         tile.owner = owner;
-        tile.setVisibility(owner.civID, true);
+        if (owner.civID) {
+            tile.setVisibility(owner.civID, true);
+        }
         owner.addTile(coords);
     }
     getCivTile(civID, tile) {
+        return tile.getVisibleData(civID);
         if (tile.discoveredBy[civID]) {
             if (tile.visibleTo[civID]) {
                 return tile.getVisibleData(civID);
@@ -262,7 +267,8 @@ class Map {
         // mark tiles currently visible by unit as unseen
         const srcVisible = this.getVisibleTilesCoords(unit);
         for (const visibleCoords of srcVisible) {
-            this.setTileVisibility(unit.civID, visibleCoords, false);
+            if (unit.civID !== undefined)
+                this.setTileVisibility(unit.civID, visibleCoords, false);
         }
         this.getTile(unit.coords).setUnit(undefined);
         this.tileUpdate(unit.coords);
@@ -272,7 +278,8 @@ class Map {
         // mark tiles now visible by unit as seen
         const newVisible = this.getVisibleTilesCoords(unit);
         for (const visibleCoords of newVisible) {
-            this.setTileVisibility(unit.civID, visibleCoords, true);
+            if (unit.civID !== undefined)
+                this.setTileVisibility(unit.civID, visibleCoords, true);
         }
     }
     addTrader(trader) {
@@ -367,6 +374,16 @@ class Map {
             tile.type !== 'coastal' &&
             tile.type !== 'frozen_coastal' &&
             tile.type !== 'river');
+    }
+    newBarbarianCampAt(coords) {
+        const tile = this.getTile(coords);
+        if (!this.canSettleOn(tile))
+            return null;
+        const camp = new city_1.BarbarianCamp(coords);
+        this.cities.push(camp);
+        const cityID = this.cities.length - 1;
+        this.buildImprovementAt(coords, 'barbarian_camp');
+        return cityID;
     }
     settleCityAt(coords, name, civID, settler) {
         const tile = this.getTile(coords);

--- a/dist/server/game/map/index.js
+++ b/dist/server/game/map/index.js
@@ -18,9 +18,10 @@ const TRADER_CAPACITY = {
     science: 5,
 };
 class Map {
-    constructor(height, width) {
+    constructor(height, width, seed) {
         this.height = height;
         this.width = width;
+        this.seed = seed;
         this.tiles = new Array(height * width);
         this.cities = [];
         this.traders = [];
@@ -30,6 +31,7 @@ class Map {
         return {
             height: this.height,
             width: this.width,
+            seed: this.seed,
             tiles: this.tiles.map(tile => tile.export()),
             cities: this.cities.map(city => city.export()),
             traders: this.traders.map(trader => trader.export()),
@@ -43,7 +45,7 @@ class Map {
      * @returns
      */
     static import(world, data) {
-        const map = new Map(data.height, data.width);
+        const map = new Map(data.height, data.width, data.seed);
         map.tiles = data.tiles.map(tileData => tile_1.Tile.import(tileData));
         map.cities = data.cities.map(cityData => {
             const city = city_1.City.import(cityData);

--- a/dist/server/game/map/tile/city.js
+++ b/dist/server/game/map/tile/city.js
@@ -112,10 +112,6 @@ class BarbarianCamp extends UnitController {
                     x: world.random.randInt(0, map.width - 1),
                     y: world.random.randInt(0, map.height - 1),
                 };
-                unit.automationData.wanderTarget = {
-                    x: 33,
-                    y: 33,
-                };
             }
             const currentTarget = (_a = unit.automationData.target) !== null && _a !== void 0 ? _a : unit.automationData.wanderTarget;
             let stepsTaken = 0;
@@ -152,10 +148,10 @@ class BarbarianCamp extends UnitController {
                 }
                 if (stepsTaken === 0) {
                     // If there is no movement we can make towards our target, let switch to a new one.
-                    // unit.automationData.wanderTarget = {
-                    //   x: world.random.randInt(0, map.width),
-                    //   y: world.random.randInt(0, map.height),
-                    // };
+                    unit.automationData.wanderTarget = {
+                        x: world.random.randInt(0, map.width),
+                        y: world.random.randInt(0, map.height),
+                    };
                 }
                 break;
             }

--- a/dist/server/game/map/tile/city.js
+++ b/dist/server/game/map/tile/city.js
@@ -267,7 +267,7 @@ class BarbarianCamp extends UnitController {
             while (unit.movement > 0) {
                 i++;
                 const adjacentCoords = (0, utils_1.getAdjacentCoords)(unit.coords);
-                const [targetXDiff, targetYDiff] = (0, utils_1.getSmallesCoordsDiff)(map, unit.coords, currentTarget);
+                const [targetXDiff, targetYDiff] = (0, utils_1.getSmallestCoordsDiff)(map, unit.coords, currentTarget);
                 let directRoute = null;
                 const altRoutes = [];
                 for (const coord of adjacentCoords) {

--- a/dist/server/game/map/tile/city.js
+++ b/dist/server/game/map/tile/city.js
@@ -1,6 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.BarbarianCamp = exports.City = void 0;
+exports.BarbarianCamp = exports.UnitController = exports.City = void 0;
+const utils_1 = require("../../../utils");
 class City {
     constructor(center, name, civID) {
         this.center = center;
@@ -64,11 +65,101 @@ class City {
             this.units.splice(unitIndex, 1);
         }
     }
+    turn(world, map) {
+        // By default, do nothing (for now)
+    }
 }
 exports.City = City;
-class BarbarianCamp extends City {
+class UnitController extends City {
+    moveUnit(unit, toPos) {
+        const tile = this.map.getTile(toPos);
+        if (!tile)
+            return false;
+        const movementCost = tile.getMovementCost(unit, (0, utils_1.getDirection)(toPos, unit.coords));
+        if (!(unit.movement < movementCost)) {
+            if (tile.unit)
+                return false;
+            this.map.moveUnitTo(unit, toPos);
+            unit.movement -= movementCost;
+            return true;
+        }
+        else {
+            return false;
+        }
+    }
+    turn(world, map) {
+        super.turn(world, map);
+        if (!this.map) {
+            this.map = map;
+        }
+    }
+}
+exports.UnitController = UnitController;
+class BarbarianCamp extends UnitController {
     constructor(center) {
         super(center, 'camp', undefined);
+    }
+    turn(world, map) {
+        super.turn(world, map);
+        this.units.forEach(unit => {
+            var _a;
+            unit.newTurn();
+            const visibleCoords = map.getVisibleTilesCoords(unit, unit.visionRange);
+            if (unit.type === 'scout') {
+            }
+            if (!('wanderTarget' in unit.automationData)) {
+                unit.automationData.wanderTarget = {
+                    x: world.random.randInt(0, map.width - 1),
+                    y: world.random.randInt(0, map.height - 1),
+                };
+                unit.automationData.wanderTarget = {
+                    x: 33,
+                    y: 33,
+                };
+            }
+            const currentTarget = (_a = unit.automationData.target) !== null && _a !== void 0 ? _a : unit.automationData.wanderTarget;
+            let stepsTaken = 0;
+            while (unit.movement > 0) {
+                const adjacentCoords = (0, utils_1.getAdjacentCoords)(unit.coords);
+                const [targetXDiff, targetYDiff] = (0, utils_1.getSmallesCoordsDiff)(map, unit.coords, currentTarget);
+                let directRoute = null;
+                const altRoutes = [];
+                for (const coord of adjacentCoords) {
+                    const [xDiff, yDiff] = [coord.x - unit.coords.x, coord.y - unit.coords.y];
+                    if (Math.sign(targetXDiff) === xDiff && Math.sign(targetYDiff) === yDiff) {
+                        directRoute = coord;
+                    }
+                    else if ((xDiff && Math.sign(targetXDiff) === xDiff) || (yDiff && Math.sign(targetYDiff) === yDiff)) {
+                        altRoutes.push(coord);
+                    }
+                }
+                if (directRoute && map.areValidCoords(directRoute) && this.moveUnit(unit, directRoute)) {
+                    stepsTaken++;
+                    continue;
+                }
+                else {
+                    let didMove = false;
+                    for (const dst of altRoutes) {
+                        if (map.areValidCoords(dst) && this.moveUnit(unit, dst)) {
+                            stepsTaken++;
+                            didMove = true;
+                            break;
+                        }
+                    }
+                    if (didMove) {
+                        continue;
+                    }
+                }
+                if (stepsTaken === 0) {
+                    // If there is no movement we can make towards our target, let switch to a new one.
+                    // unit.automationData.wanderTarget = {
+                    //   x: world.random.randInt(0, map.width),
+                    //   y: world.random.randInt(0, map.height),
+                    // };
+                }
+                break;
+            }
+        });
     }
 }
 exports.BarbarianCamp = BarbarianCamp;

--- a/dist/server/game/map/tile/city.js
+++ b/dist/server/game/map/tile/city.js
@@ -2,8 +2,10 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.BarbarianCamp = exports.UnitController = exports.City = void 0;
 const utils_1 = require("../../../utils");
+const errand_1 = require("./errand");
 class City {
-    constructor(center, name, civID) {
+    constructor(id, center, name, civID) {
+        this.id = id;
         this.center = center;
         this.name = name;
         this.civID = civID;
@@ -96,16 +98,65 @@ class UnitController extends City {
 }
 exports.UnitController = UnitController;
 class BarbarianCamp extends UnitController {
-    constructor(center) {
-        super(center, 'camp', undefined);
+    constructor(id, center) {
+        super(id, center, 'camp', undefined);
     }
     turn(world, map) {
         super.turn(world, map);
+        const camp = map.getTile(this.center).improvement;
+        if (!camp.errand) {
+            let raidMode;
+            if (this.raidTarget && !this.settleTarget) {
+                raidMode = true;
+            }
+            else if (!this.raidTarget && this.settleTarget) {
+                raidMode = false;
+            }
+            else {
+                raidMode = Boolean(world.random.randInt(0, 1));
+            }
+            if (raidMode) {
+                // TODO
+            }
+            else {
+                map.startErrandAt(this.center, camp, {
+                    type: errand_1.ErrandType.UNIT_TRAINING,
+                    option: 'settler',
+                    location: this.center,
+                });
+            }
+        }
         this.units.forEach(unit => {
             var _a;
             unit.newTurn();
             const visibleCoords = map.getVisibleTilesCoords(unit, unit.visionRange);
+            const canSeeCamp = (0, utils_1.arrayIncludesCoords)(visibleCoords, this.center);
             if (unit.type === 'scout') {
+                if (!('turnsSinceCampSpotted' in unit.automationData)) {
+                    unit.automationData.turnsSinceCampSpotted = 0;
+                }
+                unit.automationData.turnsSinceCampSpotted++;
+                visibleCoords.forEach(coords => {
+                    var _a, _b;
+                    const tile = map.getTile(coords);
+                    if (tile.improvement) {
+                        if (tile.improvement.type === 'barbarian_camp') {
+                            unit.automationData.turnsSinceCampSpotted = 0;
+                            if (!(coords.x === this.center.x && coords.y === this.center.y)) {
+                                unit.automationData.target = this.center;
+                                delete unit.automationData.wanderTarget;
+                            }
+                            else if (unit.automationData.target) {
+                                this.raidTarget = (_a = unit.automationData.raidTarget) !== null && _a !== void 0 ? _a : this.raidTarget;
+                                this.settleTarget = (_b = unit.automationData.settleTarget) !== null && _b !== void 0 ? _b : this.settleTarget;
+                            }
+                        }
+                    }
+                    if (unit.automationData.turnsSinceCampSpotted > 3 && !canSeeCamp) {
+                        if (map.canSettleOn(tile) && !unit.automationData.settleTarget) {
+                        }
+                    }
+                });
             }
             if (!('wanderTarget' in unit.automationData)) {
                 unit.automationData.wanderTarget = {
@@ -113,9 +164,16 @@ class BarbarianCamp extends UnitController {
                     y: world.random.randInt(0, map.height - 1),
                 };
             }
-            const currentTarget = (_a = unit.automationData.target) !== null && _a !== void 0 ? _a : unit.automationData.wanderTarget;
+            if (unit.automationData.target && ((unit.coords.x === unit.automationData.target.x && unit.coords.y === unit.automationData.target.y) ||
+                (0, utils_1.arrayIncludesCoords)((0, utils_1.getAdjacentCoords)(unit.coords), unit.automationData.target))) {
+                delete unit.automationData.target;
+            }
+            let currentTarget = (_a = unit.automationData.target) !== null && _a !== void 0 ? _a : unit.automationData.wanderTarget;
             let stepsTaken = 0;
+            let i = 0;
+            console.log(unit.coords, unit.automationData);
             while (unit.movement > 0) {
+                i++;
                 const adjacentCoords = (0, utils_1.getAdjacentCoords)(unit.coords);
                 const [targetXDiff, targetYDiff] = (0, utils_1.getSmallesCoordsDiff)(map, unit.coords, currentTarget);
                 let directRoute = null;
@@ -125,10 +183,16 @@ class BarbarianCamp extends UnitController {
                     if (Math.sign(targetXDiff) === xDiff && Math.sign(targetYDiff) === yDiff) {
                         directRoute = coord;
                     }
-                    else if ((xDiff && Math.sign(targetXDiff) === xDiff) || (yDiff && Math.sign(targetYDiff) === yDiff)) {
+                    else if ((xDiff && !yDiff && Math.sign(targetXDiff) === xDiff) || (yDiff && !xDiff && Math.sign(targetYDiff) === yDiff)) {
                         altRoutes.push(coord);
                     }
                 }
+                if (!(directRoute || altRoutes.length > 0) || i > 100) {
+                    console.warn(`Barbarian unit seems to be stuck at ${JSON.stringify(unit.coords)}. Skipping.`);
+                    delete unit.automationData.wanderTarget;
+                    break;
+                }
+                console.log(directRoute, altRoutes);
                 if (directRoute && map.areValidCoords(directRoute) && this.moveUnit(unit, directRoute)) {
                     stepsTaken++;
                     continue;
@@ -147,6 +211,10 @@ class BarbarianCamp extends UnitController {
                     }
                 }
                 if (stepsTaken === 0) {
+                    if (!(currentTarget.x === unit.automationData.wanderTarget.x && currentTarget.y === unit.automationData.wanderTarget.y)) {
+                        currentTarget = unit.automationData.wanderTarget;
+                        continue;
+                    }
                     // If there is no movement we can make towards our target, let switch to a new one.
                     unit.automationData.wanderTarget = {
                         x: world.random.randInt(0, map.width),

--- a/dist/server/game/map/tile/city.js
+++ b/dist/server/game/map/tile/city.js
@@ -1,11 +1,12 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.City = void 0;
+exports.BarbarianCamp = exports.City = void 0;
 class City {
     constructor(center, name, civID) {
         this.center = center;
         this.name = name;
         this.civID = civID;
+        this.units = [];
         this.tiles = new Set();
         this.addTile(center);
     }
@@ -18,11 +19,12 @@ class City {
             center: this.center,
             name: this.name,
             civID: this.civID,
+            isBarbarian: this instanceof BarbarianCamp,
             tiles,
         };
     }
     static import(data) {
-        const city = new City(data.center, data.name, data.civID);
+        const city = new (data.isBarbarian ? BarbarianCamp : City)(data.center, data.name, data.civID);
         city.tiles = new Set();
         for (const coords of data.tiles) {
             city.addTile(coords);
@@ -44,6 +46,30 @@ class City {
     removeTile(coords) {
         this.tiles.delete(coords);
     }
+    getUnits() {
+        return this.units;
+    }
+    getUnitPositions() {
+        return this.units.map(unit => unit.coords);
+    }
+    addUnit(unit) {
+        this.units.push(unit);
+        if (this instanceof BarbarianCamp) {
+            unit.setBarbarian(true);
+        }
+    }
+    removeUnit(unit) {
+        const unitIndex = this.units.indexOf(unit);
+        if (unitIndex > -1) {
+            this.units.splice(unitIndex, 1);
+        }
+    }
 }
 exports.City = City;
+class BarbarianCamp extends City {
+    constructor(center) {
+        super(center, 'camp', undefined);
+    }
+}
+exports.BarbarianCamp = BarbarianCamp;
 //# sourceMappingURL=city.js.map

--- a/dist/server/game/map/tile/errand.js
+++ b/dist/server/game/map/tile/errand.js
@@ -68,7 +68,7 @@ WorkErrand.errandActionEffects = {
     [ErrandType.UNIT_TRAINING]: (world, map, tile, action) => {
         if (!(tile.owner && action.location))
             return;
-        const newUnit = new unit_1.Unit(action.option, tile.owner.civID, action.location);
+        const newUnit = new unit_1.Unit(action.option, action.location, tile.owner.civID);
         if (tile.unit) {
             // if there is already a unit on this tile, we must figure something else out
         }

--- a/dist/server/game/map/tile/errand.js
+++ b/dist/server/game/map/tile/errand.js
@@ -66,6 +66,7 @@ WorkErrand.errandActionEffects = {
         tile.improvement = new improvement_1.Improvement(action.option, tile.baseYield);
     },
     [ErrandType.UNIT_TRAINING]: (world, map, tile, action) => {
+        console.log(tile, action);
         if (!(tile.owner && action.location))
             return;
         const newUnit = new unit_1.Unit(action.option, action.location, tile.owner.civID, tile.owner.civID ? undefined : tile.owner.id);

--- a/dist/server/game/map/tile/errand.js
+++ b/dist/server/game/map/tile/errand.js
@@ -66,7 +66,6 @@ WorkErrand.errandActionEffects = {
         tile.improvement = new improvement_1.Improvement(action.option, tile.baseYield);
     },
     [ErrandType.UNIT_TRAINING]: (world, map, tile, action) => {
-        console.log(tile, action);
         if (!(tile.owner && action.location))
             return;
         const newUnit = new unit_1.Unit(action.option, action.location, tile.owner.civID, tile.owner.civID ? undefined : tile.owner.id);

--- a/dist/server/game/map/tile/errand.js
+++ b/dist/server/game/map/tile/errand.js
@@ -68,7 +68,7 @@ WorkErrand.errandActionEffects = {
     [ErrandType.UNIT_TRAINING]: (world, map, tile, action) => {
         if (!(tile.owner && action.location))
             return;
-        const newUnit = new unit_1.Unit(action.option, action.location, tile.owner.civID);
+        const newUnit = new unit_1.Unit(action.option, action.location, tile.owner.civID, tile.owner.civID ? undefined : tile.owner.id);
         if (tile.unit) {
             // if there is already a unit on this tile, we must figure something else out
         }

--- a/dist/server/game/map/tile/improvement.js
+++ b/dist/server/game/map/tile/improvement.js
@@ -159,7 +159,7 @@ class Improvement {
 exports.Improvement = Improvement;
 Improvement.yieldTable = {
     'settlement': new yield_1.Yield({ food: 2, production: 2 }),
-    'barbarian_camp': new yield_1.Yield({ food: 4, production: 4 }),
+    'barbarian_camp': new yield_1.Yield({ food: 2, production: 2 }),
     'encampment': new yield_1.Yield({ production: 1 }),
     'campus': new yield_1.Yield({ science: 5 }),
     'farm': new yield_1.Yield({ food: 1 }),
@@ -167,7 +167,7 @@ Improvement.yieldTable = {
 };
 Improvement.storeCapTable = {
     'settlement': { food: 20, production: 2 },
-    'barbarian_camp': { food: 24, production: 4 },
+    'barbarian_camp': { food: 20, production: 2 },
     'encampment': { food: 10, production: 1 },
     'farm': { food: 20 },
 };

--- a/dist/server/game/map/tile/improvement.js
+++ b/dist/server/game/map/tile/improvement.js
@@ -159,6 +159,7 @@ class Improvement {
 exports.Improvement = Improvement;
 Improvement.yieldTable = {
     'settlement': new yield_1.Yield({ food: 2, production: 2 }),
+    'barbarian_camp': new yield_1.Yield({ food: 4, production: 4 }),
     'encampment': new yield_1.Yield({ production: 1 }),
     'campus': new yield_1.Yield({ science: 5 }),
     'farm': new yield_1.Yield({ food: 1 }),
@@ -166,6 +167,7 @@ Improvement.yieldTable = {
 };
 Improvement.storeCapTable = {
     'settlement': { food: 20, production: 2 },
+    'barbarian_camp': { food: 24, production: 4 },
     'encampment': { food: 10, production: 1 },
     'farm': { food: 20 },
 };

--- a/dist/server/game/map/tile/unit.js
+++ b/dist/server/game/map/tile/unit.js
@@ -30,7 +30,7 @@ var PromotionEra;
     PromotionEra[PromotionEra["ALL"] = 9] = "ALL";
 })(PromotionEra = exports.PromotionEra || (exports.PromotionEra = {}));
 class Unit {
-    constructor(type, civID, coords, knowledge) {
+    constructor(type, coords, civID, cityID, knowledge) {
         var _a;
         this.type = type;
         this.hp = 100;
@@ -43,6 +43,7 @@ class Unit {
         }
         this.visionRange = (_a = Unit.visionRangeTable[type]) !== null && _a !== void 0 ? _a : Unit.visionRangeTable.default;
         this.civID = civID;
+        this.cityID = cityID;
         this.coords = coords;
         this.alive = true;
         this.knowledge = knowledge !== null && knowledge !== void 0 ? knowledge : {};
@@ -59,6 +60,7 @@ class Unit {
             hp: this.hp,
             movement: this.movement,
             civID: this.civID,
+            cityID: this.cityID,
             coords: this.coords,
             alive: this.alive,
             knowledge: this.knowledge,
@@ -66,7 +68,7 @@ class Unit {
         };
     }
     static import(data) {
-        const unit = new Unit(data.type, data.civID, data.coords);
+        const unit = new Unit(data.type, data.coords, data.civID, data.cityID, data.knowledge);
         unit.hp = data.hp;
         unit.movement = data.movement;
         unit.promotionClass = Unit.promotionClassTable[unit.type];
@@ -92,6 +94,7 @@ class Unit {
             attackRange: this.attackRange,
             knowledge: this.knowledge,
             cloaked: this.cloaked,
+            isBarbarian: this.isBarbarian,
         } : undefined;
     }
     getMovementClass() {
@@ -99,6 +102,9 @@ class Unit {
     }
     setDead() {
         this.alive = false;
+    }
+    setBarbarian(isBarbarian) {
+        this.isBarbarian = isBarbarian;
     }
     isDead() {
         return !this.alive;

--- a/dist/server/game/map/tile/unit.js
+++ b/dist/server/game/map/tile/unit.js
@@ -47,6 +47,7 @@ class Unit {
         this.coords = coords;
         this.alive = true;
         this.knowledge = knowledge !== null && knowledge !== void 0 ? knowledge : {};
+        this.automationData = {};
         if (Unit.cloakTable[type]) {
             this.cloaked = false;
         }

--- a/dist/server/game/world.js
+++ b/dist/server/game/world.js
@@ -27,11 +27,11 @@ class World {
             });
             this.updateCivTileVisibility(civID);
         }
-        const barbarianTribes = 25; // Make this depend on map size
+        const barbarianTribes = Math.ceil(map.height * map.width / 1500);
         for (let i = 0; i < barbarianTribes; i++) {
             this.getStartLocaltion(([settlerCoords, _, scoutCoords]) => {
                 const cityID = this.map.newBarbarianCampAt(settlerCoords);
-                if (cityID)
+                if (cityID !== null)
                     this.addUnit(new unit_1.Unit('scout', scoutCoords, undefined, cityID));
             });
         }

--- a/dist/server/game/world.js
+++ b/dist/server/game/world.js
@@ -27,7 +27,7 @@ class World {
             });
             this.updateCivTileVisibility(civID);
         }
-        const barbarianTribes = 100; // Make this depend on map size
+        const barbarianTribes = 25; // Make this depend on map size
         for (let i = 0; i < barbarianTribes; i++) {
             this.getStartLocaltion(([settlerCoords, _, scoutCoords]) => {
                 const cityID = this.map.newBarbarianCampAt(settlerCoords);

--- a/dist/server/game/world.js
+++ b/dist/server/game/world.js
@@ -19,40 +19,53 @@ class World {
         this.leaderPool = {};
         for (let civID = 0; civID < this.civsCount; civID++) {
             this.civs[civID] = new civilization_1.Civilization();
-            const random = new random_1.Random(42);
-            let start_location_successful = false;
-            for (let i = 0; i < 1000; i++) {
-                const x = random.randInt(0, map.width - 1);
-                const y = random.randInt(0, map.height - 1);
-                const settler_coords = { x, y };
-                const builder_coords = { x: x + 1, y: y + 1 };
-                const scout_coords = { x: x - 1, y: y + 1 };
-                let legal_start_location = true;
-                for (const coords of [settler_coords, builder_coords, scout_coords]) {
-                    const tile = this.map.getTile(coords);
-                    if (!tile || tile.unit || !this.map.canSettleOn(tile)) {
-                        legal_start_location = false;
-                        break;
-                    }
-                }
-                if (legal_start_location) {
-                    this.addUnit(new unit_1.Unit('settler', civID, settler_coords));
-                    this.addUnit(new unit_1.Unit('builder', civID, builder_coords));
-                    this.addUnit(new unit_1.Unit('scout', civID, scout_coords));
-                    start_location_successful = true;
-                    break;
-                }
-            }
-            if (!start_location_successful) {
-                console.error("Error: couldn't find legal start location! (gave up after 1000 tries)");
-            }
+            this.getStartLocaltion(([settlerCoords, builderCoords, scoutCoords]) => {
+                this.addUnit(new unit_1.Unit('settler', settlerCoords, civID));
+                this.addUnit(new unit_1.Unit('builder', builderCoords, civID));
+                this.addUnit(new unit_1.Unit('scout', scoutCoords, civID));
+            });
             this.updateCivTileVisibility(civID);
+        }
+        const barbarianTribes = 10; // Make this depend on map size
+        for (let i = 0; i < barbarianTribes; i++) {
+            this.getStartLocaltion(([settlerCoords, _, scoutCoords]) => {
+                const cityID = this.map.newBarbarianCampAt(settlerCoords);
+                if (cityID)
+                    this.addUnit(new unit_1.Unit('scout', scoutCoords, undefined, cityID));
+            });
         }
         for (let i = 0; i < leader_1.leaderTemplates.length; i++) {
             this.leaderPool[i] = new leader_1.Leader(i);
         }
         this.currentTurn = 1;
         // this.colorPool = colorList.reduce((obj: { [color: string]: boolean }, color: string) => ({...obj, [color]: true}), {});
+    }
+    getStartLocaltion(callback) {
+        const random = new random_1.Random(42);
+        let start_location_successful = false;
+        for (let i = 0; i < 1000; i++) {
+            const x = random.randInt(0, this.map.width - 1);
+            const y = random.randInt(0, this.map.height - 1);
+            const settlerCoords = { x, y };
+            const builderCoords = { x: x + 1, y: y + 1 };
+            const scoutCoords = { x: x - 1, y: y + 1 };
+            let legal_start_location = true;
+            for (const coords of [settlerCoords, builderCoords, scoutCoords]) {
+                const tile = this.map.getTile(coords);
+                if (!tile || tile.unit || !this.map.canSettleOn(tile)) {
+                    legal_start_location = false;
+                    break;
+                }
+            }
+            if (legal_start_location) {
+                callback([settlerCoords, builderCoords, scoutCoords]);
+                start_location_successful = true;
+                break;
+            }
+        }
+        if (!start_location_successful) {
+            throw 'Error: couldn\'t find legal start location! (gave up after 1000 tries)';
+        }
     }
     export() {
         const exportedCivs = {};
@@ -184,17 +197,24 @@ class World {
     // map, civs
     addUnit(unit) {
         if (this.map.isInBounds(unit.coords)) {
-            this.civs[unit.civID].addUnit(unit);
+            if (unit.civID !== undefined)
+                this.civs[unit.civID].addUnit(unit);
+            else if (unit.cityID !== undefined)
+                this.map.cities[unit.cityID].addUnit(unit);
             this.map.getTile(unit.coords).setUnit(unit);
         }
     }
     // map, civs
     removeUnit(unit) {
-        this.civs[unit.civID].removeUnit(unit);
+        if (unit.civID !== undefined)
+            this.civs[unit.civID].removeUnit(unit);
+        else if (unit.cityID !== undefined)
+            this.map.cities[unit.cityID].removeUnit(unit);
         this.updates.push(() => ['unitKilled', [unit.coords, unit]]);
         this.map.getTile(unit.coords).setUnit(undefined);
         // TODO: make this more intelligent
-        this.updateCivTileVisibility(unit.civID);
+        if (unit.civID !== undefined)
+            this.updateCivTileVisibility(unit.civID);
         this.updates.push((civID) => ['setMap', [this.map.getCivMap(civID)]]);
     }
     rangedCombat(attacker, defender) {

--- a/dist/server/game/world.js
+++ b/dist/server/game/world.js
@@ -9,6 +9,7 @@ const leader_1 = require("./leader");
 const DAMAGE_MULTIPLIER = 20;
 class World {
     constructor(map, civsCount) {
+        this.random = new random_1.Random(42);
         this.updates = [];
         if (!(map && civsCount)) {
             return;
@@ -21,8 +22,8 @@ class World {
             this.civs[civID] = new civilization_1.Civilization();
             this.getStartLocaltion(([settlerCoords, builderCoords, scoutCoords]) => {
                 this.addUnit(new unit_1.Unit('settler', settlerCoords, civID));
-                this.addUnit(new unit_1.Unit('builder', builderCoords, civID));
-                this.addUnit(new unit_1.Unit('scout', scoutCoords, civID));
+                // this.addUnit(new Unit('builder', builderCoords, civID));
+                // this.addUnit(new Unit('scout', scoutCoords, civID));
             });
             this.updateCivTileVisibility(civID);
         }
@@ -41,11 +42,10 @@ class World {
         // this.colorPool = colorList.reduce((obj: { [color: string]: boolean }, color: string) => ({...obj, [color]: true}), {});
     }
     getStartLocaltion(callback) {
-        const random = new random_1.Random(42);
         let start_location_successful = false;
         for (let i = 0; i < 1000; i++) {
-            const x = random.randInt(0, this.map.width - 1);
-            const y = random.randInt(0, this.map.height - 1);
+            const x = this.random.randInt(0, this.map.width - 1);
+            const y = this.random.randInt(0, this.map.height - 1);
             const settlerCoords = { x, y };
             const builderCoords = { x: x + 1, y: y + 1 };
             const scoutCoords = { x: x - 1, y: y + 1 };

--- a/dist/server/game/world.js
+++ b/dist/server/game/world.js
@@ -22,8 +22,8 @@ class World {
             this.civs[civID] = new civilization_1.Civilization();
             this.getStartLocaltion(([settlerCoords, builderCoords, scoutCoords]) => {
                 this.addUnit(new unit_1.Unit('settler', settlerCoords, civID));
-                // this.addUnit(new Unit('builder', builderCoords, civID));
-                // this.addUnit(new Unit('scout', scoutCoords, civID));
+                this.addUnit(new unit_1.Unit('builder', builderCoords, civID));
+                this.addUnit(new unit_1.Unit('scout', scoutCoords, civID));
             });
             this.updateCivTileVisibility(civID);
         }

--- a/dist/server/game/world.js
+++ b/dist/server/game/world.js
@@ -9,11 +9,11 @@ const leader_1 = require("./leader");
 const DAMAGE_MULTIPLIER = 20;
 class World {
     constructor(map, civsCount) {
-        this.random = new random_1.Random(42);
         this.updates = [];
         if (!(map && civsCount)) {
             return;
         }
+        this.random = new random_1.Random(map.seed);
         this.map = map;
         this.civsCount = civsCount;
         this.civs = {};
@@ -22,12 +22,12 @@ class World {
             this.civs[civID] = new civilization_1.Civilization();
             this.getStartLocaltion(([settlerCoords, builderCoords, scoutCoords]) => {
                 this.addUnit(new unit_1.Unit('settler', settlerCoords, civID));
-                this.addUnit(new unit_1.Unit('builder', builderCoords, civID));
-                this.addUnit(new unit_1.Unit('scout', scoutCoords, civID));
+                // this.addUnit(new Unit('builder', builderCoords, civID));
+                // this.addUnit(new Unit('scout', scoutCoords, civID));
             });
             this.updateCivTileVisibility(civID);
         }
-        const barbarianTribes = 10; // Make this depend on map size
+        const barbarianTribes = 100; // Make this depend on map size
         for (let i = 0; i < barbarianTribes; i++) {
             this.getStartLocaltion(([settlerCoords, _, scoutCoords]) => {
                 const cityID = this.map.newBarbarianCampAt(settlerCoords);
@@ -64,7 +64,11 @@ class World {
             }
         }
         if (!start_location_successful) {
-            throw 'Error: couldn\'t find legal start location! (gave up after 1000 tries)';
+            throw {
+                type: 'mapError',
+                code: 'noStartLocation',
+                msg: 'Error: couldn\'t find legal start location! (gave up after 1000 tries)',
+            };
         }
     }
     export() {

--- a/dist/server/utils/index.js
+++ b/dist/server/utils/index.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getSmallesCoordsDiff = exports.arrayIncludesCoords = exports.getDirection = exports.getCoordInDirection = exports.getAdjacentCoords = exports.mod = void 0;
+exports.getSmallestCoordsDiff = exports.arrayIncludesCoords = exports.getDirection = exports.getCoordInDirection = exports.getAdjacentCoords = exports.mod = void 0;
 const mod = (a, b) => {
     if (a >= 0) {
         return a % b;
@@ -74,7 +74,7 @@ const arrayIncludesCoords = (array, { x, y }) => {
     return false;
 };
 exports.arrayIncludesCoords = arrayIncludesCoords;
-const getSmallesCoordsDiff = (map, pos, target) => {
+const getSmallestCoordsDiff = (map, pos, target) => {
     const { width } = map;
     const [posX, posY] = [(0, exports.mod)(pos.x, width), pos.y];
     const [targetX, targetY] = [target.x, target.y];
@@ -83,5 +83,5 @@ const getSmallesCoordsDiff = (map, pos, target) => {
     const altXDiff = altTargetX - posX;
     return [(Math.abs(xDiff) <= Math.abs(altXDiff)) ? (xDiff) : (altXDiff), targetY - posY];
 };
-exports.getSmallesCoordsDiff = getSmallesCoordsDiff;
+exports.getSmallestCoordsDiff = getSmallestCoordsDiff;
 //# sourceMappingURL=index.js.map

--- a/dist/server/utils/index.js
+++ b/dist/server/utils/index.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.arrayIncludesCoords = exports.getDirection = exports.getCoordInDirection = exports.getAdjacentCoords = exports.mod = void 0;
+exports.getSmallesCoordsDiff = exports.arrayIncludesCoords = exports.getDirection = exports.getCoordInDirection = exports.getAdjacentCoords = exports.mod = void 0;
 const mod = (a, b) => {
     if (a >= 0) {
         return a % b;
@@ -74,4 +74,14 @@ const arrayIncludesCoords = (array, { x, y }) => {
     return false;
 };
 exports.arrayIncludesCoords = arrayIncludesCoords;
+const getSmallesCoordsDiff = (map, pos, target) => {
+    const { width } = map;
+    const [posX, posY] = [(0, exports.mod)(pos.x, width), pos.y];
+    const [targetX, targetY] = [target.x, target.y];
+    const altTargetX = targetX < posX ? (targetX + width) : (targetX - width);
+    const xDiff = targetX - posX;
+    const altXDiff = altTargetX - posX;
+    return [(Math.abs(xDiff) <= Math.abs(altXDiff)) ? (xDiff) : (altXDiff), targetY - posY];
+};
+exports.getSmallesCoordsDiff = getSmallesCoordsDiff;
 //# sourceMappingURL=index.js.map

--- a/src/client/camera.ts
+++ b/src/client/camera.ts
@@ -190,7 +190,7 @@ class Camera {
     if (unit.cloaked) ctx.globalAlpha = 0.5;
 
     // Unit Color Background
-    ctx.fillStyle = civs[unit.civID].color;
+    ctx.fillStyle = civs[unit.civID]?.color ?? (unit.isBarbarian ? '#F00': '#333');
     ctx.beginPath();
     ctx.rect(
       (-camX + ((x - (width / 2)) * X_TILE_SPACING) + 6.5) * zoom,

--- a/src/client/camera.ts
+++ b/src/client/camera.ts
@@ -358,7 +358,7 @@ class Camera {
             }
           }
 
-          if (tile.owner) {
+          if (tile.owner && !tile.owner.isBarbarian) {
             const neighbors = world.getNeighbors({x, y}, false);
             ctx.beginPath();
             ctx.lineWidth = margin * 2;

--- a/src/client/world.ts
+++ b/src/client/world.ts
@@ -104,6 +104,7 @@ interface Tile {
   owner?: {
     civID: number,
     name: string,
+    isBarbarian: boolean,
   };
   visible: boolean;
   walls: Wall[];

--- a/src/client/world.ts
+++ b/src/client/world.ts
@@ -26,6 +26,7 @@ interface Unit {
   promotionClass: PromotionClass;
   knowledge: KnowledgeMap;
   cloaked?: boolean;
+  isBarbarian?: boolean;
 }
 
 interface RangedUnit extends Unit {

--- a/src/server/game/map/generator/index.ts
+++ b/src/server/game/map/generator/index.ts
@@ -47,13 +47,12 @@ export class PerlinWorldGenerator {
   private seaLevel: number;
   private biomes: { [key: string]: Biome }
 
-  constructor(seed: number, { width, height }: MapOptions) {
-    this.seed = seed;
-    this.random = new Random(seed);
+  constructor(seed: number | undefined, { width, height }: MapOptions) {
+    this.reseed(seed);
     this.simplex = new SimplexNoise(this.random.randFloat);
     this.width = width;
     this.height = height;
-
+    
     // Elevation Constants - Make these configurable later
     const OCEAN_LEVEL = 45;
     const COAST_LEVEL = 55;
@@ -61,9 +60,9 @@ export class PerlinWorldGenerator {
     const HILLS_LEVEL = 80;
     const HIGHLANDS_LEVEL = 90;
     const MOUNTAIN_LEVEL = 98;
-
+    
     this.seaLevel = COAST_LEVEL;
-
+    
     // Define Biomes
     this.biomes = {
       'plains': new Biome(this.random,
@@ -125,6 +124,11 @@ export class PerlinWorldGenerator {
         ]
       ),
     };
+  }
+
+  reseed(seed?: number): void {
+    this.seed = seed ?? Math.floor(Math.random() * 9007199254740991);
+    this.random = new Random(this.seed);
   }
 
   getBiome(temp: number, humidity: number): Biome {
@@ -237,7 +241,7 @@ export class PerlinWorldGenerator {
       }
     }
 
-    console.log(`Map generation completed in ${new Date().getTime() - startTime}ms.`)
+    console.log(`Map generation completed in ${new Date().getTime() - startTime}ms with seed ${this.seed}.`)
     return map;
   }
 }

--- a/src/server/game/map/generator/index.ts
+++ b/src/server/game/map/generator/index.ts
@@ -48,87 +48,87 @@ export class PerlinWorldGenerator {
   private biomes: { [key: string]: Biome }
 
   constructor(seed: number | undefined, { width, height }: MapOptions) {
-    this.reseed(seed);
-    this.simplex = new SimplexNoise(this.random.randFloat);
     this.width = width;
     this.height = height;
-    
-    // Elevation Constants - Make these configurable later
-    const OCEAN_LEVEL = 45;
-    const COAST_LEVEL = 55;
-    const PLAINS_LEVEL = 60;
-    const HILLS_LEVEL = 80;
-    const HIGHLANDS_LEVEL = 90;
-    const MOUNTAIN_LEVEL = 98;
-    
-    this.seaLevel = COAST_LEVEL;
-    
-    // Define Biomes
-    this.biomes = {
-      'plains': new Biome(this.random,
-        OCEAN, [
-          [OCEAN_LEVEL, SHALLOW_OCEAN],
-          [COAST_LEVEL, GRASS_LOWLANDS],
-          [PLAINS_LEVEL, GRASS_PLAINS],
-          [HILLS_LEVEL, new TilePool([[GRASS_HILLS, 100], [MOUNTAIN_SPRING, 1]])],
-          [HIGHLANDS_LEVEL, new TilePool([[GRASS_MOUNTAINS, 100], [MOUNTAIN_SPRING, 1]])],
-          [MOUNTAIN_LEVEL, new TilePool([[MOUNTAIN, 20], [MOUNTAIN_SPRING, 1]])],
-        ]
-      ),
-      'temperate_forest': new Biome(this.random,
-        OCEAN, [
-          [OCEAN_LEVEL, SHALLOW_OCEAN],
-          [COAST_LEVEL, TEMPERATE_FOREST_LOWLANDS],
-          [PLAINS_LEVEL, TEMPERATE_FOREST_PLAINS],
-          [HILLS_LEVEL, new TilePool([[TEMPERATE_FOREST_HILLS, 100], [MOUNTAIN_SPRING, 1]])],
-          [HIGHLANDS_LEVEL, new TilePool([[TEMPERATE_FOREST_MOUNTAINS, 100], [MOUNTAIN_SPRING, 1]])],
-          [MOUNTAIN_LEVEL, new TilePool([[MOUNTAIN, 20], [MOUNTAIN_SPRING, 1]])],
-        ]
-      ),
-      'tundra': new Biome(this.random,
-        OCEAN, [
-          [OCEAN_LEVEL, SHALLOW_OCEAN],
-          [OCEAN_LEVEL + 5, FROZEN_RIVER],
-          [COAST_LEVEL, SNOW_PLAINS],
-          [HILLS_LEVEL, SNOW_HILLS],
-          [HIGHLANDS_LEVEL, SNOW_MOUNTAINS],
-          [MOUNTAIN_LEVEL, MOUNTAIN],
-        ]
-      ),
-      'arctic': new Biome(this.random,
-        FROZEN_OCEAN, [
-          [OCEAN_LEVEL, SHALLOW_FROZEN_OCEAN],
-          [COAST_LEVEL, SNOW_PLAINS],
-          [HILLS_LEVEL, SNOW_HILLS],
-          [HIGHLANDS_LEVEL, SNOW_MOUNTAINS],
-          [MOUNTAIN_LEVEL, MOUNTAIN],
-        ]
-      ),
-      'desert': new Biome(this.random,
-        OCEAN, [
-          [OCEAN_LEVEL, SHALLOW_OCEAN],
-          [COAST_LEVEL, DESERT_PLAINS],
-          [HILLS_LEVEL, DESERT_HILLS],
-          [HIGHLANDS_LEVEL, DESERT_MOUNTAINS],
-          [MOUNTAIN_LEVEL, new TilePool([[MOUNTAIN, 15], [MOUNTAIN_SPRING, 1]])],
-        ]
-      ),
-      'mild_desert': new Biome(this.random,
-        OCEAN, [
-          [OCEAN_LEVEL, SHALLOW_OCEAN],
-          [COAST_LEVEL, new TilePool([[DESERT_PLAINS, 3], [GRASS_LOWLANDS, 1]])], // TODO - replace grass lowlands with desert lowlands
-          [PLAINS_LEVEL, DESERT_PLAINS],
-          [HILLS_LEVEL, DESERT_HILLS],
-          [HIGHLANDS_LEVEL, DESERT_MOUNTAINS],
-          [MOUNTAIN_LEVEL, new TilePool([[MOUNTAIN, 15], [MOUNTAIN_SPRING, 1]])],
-        ]
-      ),
-    };
+    this.reseed(seed);
   }
 
   reseed(seed?: number): void {
     this.seed = seed ?? Math.floor(Math.random() * 9007199254740991);
     this.random = new Random(this.seed);
+    this.simplex = new SimplexNoise(this.random.randFloat);
+
+     // Elevation Constants - Make these configurable later
+     const OCEAN_LEVEL = 45;
+     const COAST_LEVEL = 55;
+     const PLAINS_LEVEL = 60;
+     const HILLS_LEVEL = 80;
+     const HIGHLANDS_LEVEL = 90;
+     const MOUNTAIN_LEVEL = 98;
+     
+     this.seaLevel = COAST_LEVEL;
+     
+     // Define Biomes
+     this.biomes = {
+       'plains': new Biome(this.random,
+         OCEAN, [
+           [OCEAN_LEVEL, SHALLOW_OCEAN],
+           [COAST_LEVEL, GRASS_LOWLANDS],
+           [PLAINS_LEVEL, GRASS_PLAINS],
+           [HILLS_LEVEL, new TilePool([[GRASS_HILLS, 100], [MOUNTAIN_SPRING, 1]])],
+           [HIGHLANDS_LEVEL, new TilePool([[GRASS_MOUNTAINS, 100], [MOUNTAIN_SPRING, 1]])],
+           [MOUNTAIN_LEVEL, new TilePool([[MOUNTAIN, 20], [MOUNTAIN_SPRING, 1]])],
+         ]
+       ),
+       'temperate_forest': new Biome(this.random,
+         OCEAN, [
+           [OCEAN_LEVEL, SHALLOW_OCEAN],
+           [COAST_LEVEL, TEMPERATE_FOREST_LOWLANDS],
+           [PLAINS_LEVEL, TEMPERATE_FOREST_PLAINS],
+           [HILLS_LEVEL, new TilePool([[TEMPERATE_FOREST_HILLS, 100], [MOUNTAIN_SPRING, 1]])],
+           [HIGHLANDS_LEVEL, new TilePool([[TEMPERATE_FOREST_MOUNTAINS, 100], [MOUNTAIN_SPRING, 1]])],
+           [MOUNTAIN_LEVEL, new TilePool([[MOUNTAIN, 20], [MOUNTAIN_SPRING, 1]])],
+         ]
+       ),
+       'tundra': new Biome(this.random,
+         OCEAN, [
+           [OCEAN_LEVEL, SHALLOW_OCEAN],
+           [OCEAN_LEVEL + 5, FROZEN_RIVER],
+           [COAST_LEVEL, SNOW_PLAINS],
+           [HILLS_LEVEL, SNOW_HILLS],
+           [HIGHLANDS_LEVEL, SNOW_MOUNTAINS],
+           [MOUNTAIN_LEVEL, MOUNTAIN],
+         ]
+       ),
+       'arctic': new Biome(this.random,
+         FROZEN_OCEAN, [
+           [OCEAN_LEVEL, SHALLOW_FROZEN_OCEAN],
+           [COAST_LEVEL, SNOW_PLAINS],
+           [HILLS_LEVEL, SNOW_HILLS],
+           [HIGHLANDS_LEVEL, SNOW_MOUNTAINS],
+           [MOUNTAIN_LEVEL, MOUNTAIN],
+         ]
+       ),
+       'desert': new Biome(this.random,
+         OCEAN, [
+           [OCEAN_LEVEL, SHALLOW_OCEAN],
+           [COAST_LEVEL, DESERT_PLAINS],
+           [HILLS_LEVEL, DESERT_HILLS],
+           [HIGHLANDS_LEVEL, DESERT_MOUNTAINS],
+           [MOUNTAIN_LEVEL, new TilePool([[MOUNTAIN, 15], [MOUNTAIN_SPRING, 1]])],
+         ]
+       ),
+       'mild_desert': new Biome(this.random,
+         OCEAN, [
+           [OCEAN_LEVEL, SHALLOW_OCEAN],
+           [COAST_LEVEL, new TilePool([[DESERT_PLAINS, 3], [GRASS_LOWLANDS, 1]])], // TODO - replace grass lowlands with desert lowlands
+           [PLAINS_LEVEL, DESERT_PLAINS],
+           [HILLS_LEVEL, DESERT_HILLS],
+           [HIGHLANDS_LEVEL, DESERT_MOUNTAINS],
+           [MOUNTAIN_LEVEL, new TilePool([[MOUNTAIN, 15], [MOUNTAIN_SPRING, 1]])],
+         ]
+       ),
+     };
   }
 
   getBiome(temp: number, humidity: number): Biome {

--- a/src/server/game/map/generator/index.ts
+++ b/src/server/game/map/generator/index.ts
@@ -58,77 +58,77 @@ export class PerlinWorldGenerator {
     this.random = new Random(this.seed);
     this.simplex = new SimplexNoise(this.random.randFloat);
 
-     // Elevation Constants - Make these configurable later
-     const OCEAN_LEVEL = 45;
-     const COAST_LEVEL = 55;
-     const PLAINS_LEVEL = 60;
-     const HILLS_LEVEL = 80;
-     const HIGHLANDS_LEVEL = 90;
-     const MOUNTAIN_LEVEL = 98;
-     
-     this.seaLevel = COAST_LEVEL;
-     
-     // Define Biomes
-     this.biomes = {
-       'plains': new Biome(this.random,
-         OCEAN, [
-           [OCEAN_LEVEL, SHALLOW_OCEAN],
-           [COAST_LEVEL, GRASS_LOWLANDS],
-           [PLAINS_LEVEL, GRASS_PLAINS],
-           [HILLS_LEVEL, new TilePool([[GRASS_HILLS, 100], [MOUNTAIN_SPRING, 1]])],
-           [HIGHLANDS_LEVEL, new TilePool([[GRASS_MOUNTAINS, 100], [MOUNTAIN_SPRING, 1]])],
-           [MOUNTAIN_LEVEL, new TilePool([[MOUNTAIN, 20], [MOUNTAIN_SPRING, 1]])],
-         ]
-       ),
-       'temperate_forest': new Biome(this.random,
-         OCEAN, [
-           [OCEAN_LEVEL, SHALLOW_OCEAN],
-           [COAST_LEVEL, TEMPERATE_FOREST_LOWLANDS],
-           [PLAINS_LEVEL, TEMPERATE_FOREST_PLAINS],
-           [HILLS_LEVEL, new TilePool([[TEMPERATE_FOREST_HILLS, 100], [MOUNTAIN_SPRING, 1]])],
-           [HIGHLANDS_LEVEL, new TilePool([[TEMPERATE_FOREST_MOUNTAINS, 100], [MOUNTAIN_SPRING, 1]])],
-           [MOUNTAIN_LEVEL, new TilePool([[MOUNTAIN, 20], [MOUNTAIN_SPRING, 1]])],
-         ]
-       ),
-       'tundra': new Biome(this.random,
-         OCEAN, [
-           [OCEAN_LEVEL, SHALLOW_OCEAN],
-           [OCEAN_LEVEL + 5, FROZEN_RIVER],
-           [COAST_LEVEL, SNOW_PLAINS],
-           [HILLS_LEVEL, SNOW_HILLS],
-           [HIGHLANDS_LEVEL, SNOW_MOUNTAINS],
-           [MOUNTAIN_LEVEL, MOUNTAIN],
-         ]
-       ),
-       'arctic': new Biome(this.random,
-         FROZEN_OCEAN, [
-           [OCEAN_LEVEL, SHALLOW_FROZEN_OCEAN],
-           [COAST_LEVEL, SNOW_PLAINS],
-           [HILLS_LEVEL, SNOW_HILLS],
-           [HIGHLANDS_LEVEL, SNOW_MOUNTAINS],
-           [MOUNTAIN_LEVEL, MOUNTAIN],
-         ]
-       ),
-       'desert': new Biome(this.random,
-         OCEAN, [
-           [OCEAN_LEVEL, SHALLOW_OCEAN],
-           [COAST_LEVEL, DESERT_PLAINS],
-           [HILLS_LEVEL, DESERT_HILLS],
-           [HIGHLANDS_LEVEL, DESERT_MOUNTAINS],
-           [MOUNTAIN_LEVEL, new TilePool([[MOUNTAIN, 15], [MOUNTAIN_SPRING, 1]])],
-         ]
-       ),
-       'mild_desert': new Biome(this.random,
-         OCEAN, [
-           [OCEAN_LEVEL, SHALLOW_OCEAN],
-           [COAST_LEVEL, new TilePool([[DESERT_PLAINS, 3], [GRASS_LOWLANDS, 1]])], // TODO - replace grass lowlands with desert lowlands
-           [PLAINS_LEVEL, DESERT_PLAINS],
-           [HILLS_LEVEL, DESERT_HILLS],
-           [HIGHLANDS_LEVEL, DESERT_MOUNTAINS],
-           [MOUNTAIN_LEVEL, new TilePool([[MOUNTAIN, 15], [MOUNTAIN_SPRING, 1]])],
-         ]
-       ),
-     };
+    // Elevation Constants - Make these configurable later
+    const OCEAN_LEVEL = 45;
+    const COAST_LEVEL = 55;
+    const PLAINS_LEVEL = 60;
+    const HILLS_LEVEL = 80;
+    const HIGHLANDS_LEVEL = 90;
+    const MOUNTAIN_LEVEL = 98;
+    
+    this.seaLevel = COAST_LEVEL;
+    
+    // Define Biomes
+    this.biomes = {
+      'plains': new Biome(this.random,
+        OCEAN, [
+          [OCEAN_LEVEL, SHALLOW_OCEAN],
+          [COAST_LEVEL, GRASS_LOWLANDS],
+          [PLAINS_LEVEL, GRASS_PLAINS],
+          [HILLS_LEVEL, new TilePool([[GRASS_HILLS, 100], [MOUNTAIN_SPRING, 1]])],
+          [HIGHLANDS_LEVEL, new TilePool([[GRASS_MOUNTAINS, 100], [MOUNTAIN_SPRING, 1]])],
+          [MOUNTAIN_LEVEL, new TilePool([[MOUNTAIN, 20], [MOUNTAIN_SPRING, 1]])],
+        ]
+      ),
+      'temperate_forest': new Biome(this.random,
+        OCEAN, [
+          [OCEAN_LEVEL, SHALLOW_OCEAN],
+          [COAST_LEVEL, TEMPERATE_FOREST_LOWLANDS],
+          [PLAINS_LEVEL, TEMPERATE_FOREST_PLAINS],
+          [HILLS_LEVEL, new TilePool([[TEMPERATE_FOREST_HILLS, 100], [MOUNTAIN_SPRING, 1]])],
+          [HIGHLANDS_LEVEL, new TilePool([[TEMPERATE_FOREST_MOUNTAINS, 100], [MOUNTAIN_SPRING, 1]])],
+          [MOUNTAIN_LEVEL, new TilePool([[MOUNTAIN, 20], [MOUNTAIN_SPRING, 1]])],
+        ]
+      ),
+      'tundra': new Biome(this.random,
+        OCEAN, [
+          [OCEAN_LEVEL, SHALLOW_OCEAN],
+          [OCEAN_LEVEL + 5, FROZEN_RIVER],
+          [COAST_LEVEL, SNOW_PLAINS],
+          [HILLS_LEVEL, SNOW_HILLS],
+          [HIGHLANDS_LEVEL, SNOW_MOUNTAINS],
+          [MOUNTAIN_LEVEL, MOUNTAIN],
+        ]
+      ),
+      'arctic': new Biome(this.random,
+        FROZEN_OCEAN, [
+          [OCEAN_LEVEL, SHALLOW_FROZEN_OCEAN],
+          [COAST_LEVEL, SNOW_PLAINS],
+          [HILLS_LEVEL, SNOW_HILLS],
+          [HIGHLANDS_LEVEL, SNOW_MOUNTAINS],
+          [MOUNTAIN_LEVEL, MOUNTAIN],
+        ]
+      ),
+      'desert': new Biome(this.random,
+        OCEAN, [
+          [OCEAN_LEVEL, SHALLOW_OCEAN],
+          [COAST_LEVEL, DESERT_PLAINS],
+          [HILLS_LEVEL, DESERT_HILLS],
+          [HIGHLANDS_LEVEL, DESERT_MOUNTAINS],
+          [MOUNTAIN_LEVEL, new TilePool([[MOUNTAIN, 15], [MOUNTAIN_SPRING, 1]])],
+        ]
+      ),
+      'mild_desert': new Biome(this.random,
+        OCEAN, [
+          [OCEAN_LEVEL, SHALLOW_OCEAN],
+          [COAST_LEVEL, new TilePool([[DESERT_PLAINS, 3], [GRASS_LOWLANDS, 1]])], // TODO - replace grass lowlands with desert lowlands
+          [PLAINS_LEVEL, DESERT_PLAINS],
+          [HILLS_LEVEL, DESERT_HILLS],
+          [HIGHLANDS_LEVEL, DESERT_MOUNTAINS],
+          [MOUNTAIN_LEVEL, new TilePool([[MOUNTAIN, 15], [MOUNTAIN_SPRING, 1]])],
+        ]
+      ),
+    };
   }
 
   getBiome(temp: number, humidity: number): Biome {

--- a/src/server/game/map/generator/index.ts
+++ b/src/server/game/map/generator/index.ts
@@ -40,6 +40,7 @@ const MOUNTAIN_SPRING = new TileType('mountain', 5, {}, null, false, false, true
 export class PerlinWorldGenerator {
 
   private random: Random;
+  private seed: number;
   private simplex: SimplexNoise;
   private width: number;
   private height: number;
@@ -47,6 +48,7 @@ export class PerlinWorldGenerator {
   private biomes: { [key: string]: Biome }
 
   constructor(seed: number, { width, height }: MapOptions) {
+    this.seed = seed;
     this.random = new Random(seed);
     this.simplex = new SimplexNoise(this.random.randFloat);
     this.width = width;
@@ -220,7 +222,7 @@ export class PerlinWorldGenerator {
       river.generate(tileTypeMap, heightMap, RIVER);
     }
 
-    const map = new Map(height, width);
+    const map = new Map(height, width, this.seed);
 
     let i = 0;
     for (let y = 0; y < height; y++) {

--- a/src/server/game/map/index.ts
+++ b/src/server/game/map/index.ts
@@ -482,6 +482,8 @@ export class Map {
     const camp: BarbarianCamp = new BarbarianCamp(cityID, coords);
     this.cities.push(camp);
 
+    this.setTileOwner(coords, camp, false);
+
     this.buildImprovementAt(coords, 'barbarian_camp');
     return cityID;
   }

--- a/src/server/game/map/index.ts
+++ b/src/server/game/map/index.ts
@@ -478,9 +478,9 @@ export class Map {
     const tile = this.getTile(coords);
     if (!this.canSettleOn(tile)) return null;
 
-    const camp: BarbarianCamp = new BarbarianCamp(coords);
+    const cityID = this.cities.length;
+    const camp: BarbarianCamp = new BarbarianCamp(cityID, coords);
     this.cities.push(camp);
-    const cityID = this.cities.length - 1;
 
     this.buildImprovementAt(coords, 'barbarian_camp');
     return cityID;
@@ -490,7 +490,8 @@ export class Map {
     const tile = this.getTile(coords);
     if (!this.canSettleOn(tile)) return false;
 
-    const city: City = new City(coords, name, civID);
+    const cityID = this.cities.length;
+    const city: City = new City(cityID, coords, name, civID);
     this.cities.push(city);
 
     for (const neighbor of this.getNeighborsCoords(coords)) {

--- a/src/server/game/map/index.ts
+++ b/src/server/game/map/index.ts
@@ -25,15 +25,17 @@ export interface MapOptions {
 export class Map {
   height: number;
   width: number;
+  seed: number;
   cities: City[];
   traders: Trader[];
   updates: { (civID: number): Event }[];
 
   private tiles: Tile[];
 
-  constructor(height: number, width: number) {
+  constructor(height: number, width: number, seed: number) {
     this.height = height;
     this.width = width;
+    this.seed = seed;
     this.tiles = new Array(height*width);
     this.cities = [];
     this.traders = [];
@@ -44,6 +46,7 @@ export class Map {
     return {
       height: this.height,
       width: this.width,
+      seed: this.seed,
       tiles: this.tiles.map(tile => tile.export()),
       cities: this.cities.map(city => city.export()),
       traders: this.traders.map(trader => trader.export()),
@@ -58,7 +61,7 @@ export class Map {
    * @returns 
    */
   static import(world: World, data: any): Map {
-    const map = new Map(data.height, data.width);
+    const map = new Map(data.height, data.width, data.seed);
     map.tiles = data.tiles.map(tileData => Tile.import(tileData));
     map.cities = data.cities.map(cityData => {
       const city = City.import(cityData);

--- a/src/server/game/map/index.ts
+++ b/src/server/game/map/index.ts
@@ -88,6 +88,10 @@ export class Map {
     };
   }
 
+  public areValidCoords(coords: Coords) {
+    return coords.y >= 0 && coords.y < this.height;
+  }
+
   getUpdates(): { (civID: number): Event }[] {
     return this.updates.splice(0);
   }
@@ -618,6 +622,8 @@ export class Map {
         }
       }
     });
+
+    this.cities.forEach(city => city.turn(world, this));
 
     // Traders
     const traderResets: (() => void)[] = [];

--- a/src/server/game/map/index.ts
+++ b/src/server/game/map/index.ts
@@ -315,7 +315,6 @@ export class Map {
   }
 
   getCivTile(civID: number, tile: Tile): TileData | null {
-    return tile.getVisibleData(civID);
     if (tile.discoveredBy[civID]) {
       if (tile.visibleTo[civID]) {
         return tile.getVisibleData(civID);

--- a/src/server/game/map/tile/city.ts
+++ b/src/server/game/map/tile/city.ts
@@ -105,28 +105,23 @@ export class City {
 }
 
 export class UnitController extends City {
-  private world: World;
-  private map: Map;
+  protected world: World;
+  protected map: Map;
 
   moveUnit(unit: Unit, toPos: Coords, allowCombat?: boolean): boolean {
     const tile = this.map.getTile(toPos);
     if (!tile) return false;
     const movementCost = tile.getMovementCost(unit, getDirection(toPos, unit.coords));
-    if (!(unit.movement < movementCost)) {
-      if (tile.unit) {
-        if (!allowCombat) return false;
-        else {
-          this.world.meleeCombat(unit, tile.unit);
-          unit.movement = 0;
-          return true;
-        }
-      }
-      this.map.moveUnitTo(unit, toPos);
-      unit.movement -= movementCost;
+    if (unit.movement < movementCost) return false;
+    if (tile.unit) {
+      if (!allowCombat) return false;
+      this.world.meleeCombat(unit, tile.unit);
+      unit.movement = 0;
       return true;
-    } else {
-      return false;
     }
+    this.map.moveUnitTo(unit, toPos);
+    unit.movement -= movementCost;
+    return true;
   }
 
   turn(world: World, map: Map): void {
@@ -146,10 +141,48 @@ export class BarbarianCamp extends UnitController {
     this.danger = false;
   }
 
+  handleErrands() {
+    const camp = this.map.getTile(this.center).improvement as Improvement;
+    if (camp.errand) return;
+
+    if (this.danger) {
+      this.map.startErrandAt(this.center, camp, {
+        type: ErrandType.UNIT_TRAINING,
+        option: 'warrior',
+        location: this.center,
+      });
+    } else if (!this.units.some(unit => unit.type === 'scout')) {
+      this.map.startErrandAt(this.center, camp, {
+        type: ErrandType.UNIT_TRAINING,
+        option: 'scout',
+        location: this.center,
+      });
+    } else {
+      let raidMode: boolean;
+      raidMode = true;
+      if (!this.raidTarget && this.settleTarget) {
+        raidMode = false;
+      } else if (this.settleTarget) {
+        raidMode = Boolean(this.world.random.randInt(0, 1));
+      }
+      if (this.units.some(unit => unit.type === 'settler')) {
+        raidMode = true;
+      }
+      if (raidMode) {
+        // TODO
+      } else {
+        this.map.startErrandAt(this.center, camp, {
+          type: ErrandType.UNIT_TRAINING,
+          option: 'settler',
+          location: this.center,
+        });
+      }
+    }
+  }
+
   turn(world: World, map: Map): void {
     super.turn(world, map);
 
-    const camp = map.getTile(this.center).improvement as Improvement;
     const neighborhoodCoords = map.getNeighborsCoords(this.center, 5);
     const neighborhoodTiles = neighborhoodCoords.map(coords => map.getTile(coords));
     this.danger = false;
@@ -159,41 +192,9 @@ export class BarbarianCamp extends UnitController {
         break;
       }
     }
-    if (!camp.errand) {
-      if (this.danger) {
-        map.startErrandAt(this.center, camp, {
-          type: ErrandType.UNIT_TRAINING,
-          option: 'warrior',
-          location: this.center,
-        });
-      } else if (!this.units.some(unit => unit.type === 'scout')) {
-        map.startErrandAt(this.center, camp, {
-          type: ErrandType.UNIT_TRAINING,
-          option: 'scout',
-          location: this.center,
-        });
-      } else {
-        let raidMode: boolean;
-        raidMode = true;
-        if (!this.raidTarget && this.settleTarget) {
-          raidMode = false;
-        } else if (this.settleTarget) {
-          raidMode = Boolean(world.random.randInt(0, 1));
-        }
-        if (this.units.some(unit => unit.type === 'settler')) {
-          raidMode = true;
-        }
-        if (raidMode) {
-          // TODO
-        } else {
-          map.startErrandAt(this.center, camp, {
-            type: ErrandType.UNIT_TRAINING,
-            option: 'settler',
-            location: this.center,
-          });
-        }
-      }
-    }
+
+    this.handleErrands();
+    
 
     this.units.forEach(unit => {
       unit.newTurn();

--- a/src/server/game/map/tile/city.ts
+++ b/src/server/game/map/tile/city.ts
@@ -1,19 +1,23 @@
+import { Unit } from "./unit";
+
 export interface CityData {
   name: string;
-  civID: number;
+  civID?: number;
 }
 
 export class City {
   center: Coords;
   name: string;
-  civID: number;
+  civID?: number;
+  units: Unit[];
 
   private tiles: Set<Coords>;
 
-  constructor(center: Coords, name: string, civID: number) {
+  constructor(center: Coords, name: string, civID?: number) {
     this.center = center;
     this.name = name;
     this.civID = civID;
+    this.units = [];
 
     this.tiles = new Set();
     this.addTile(center);
@@ -28,12 +32,13 @@ export class City {
       center: this.center,
       name: this.name,
       civID: this.civID,
+      isBarbarian: this instanceof BarbarianCamp,
       tiles,
     };
   }
 
   static import(data: any): City {
-    const city = new City(data.center, data.name, data.civID);
+    const city = new (data.isBarbarian ? BarbarianCamp : City)(data.center, data.name, data.civID);
     city.tiles = new Set();
     for (const coords of data.tiles) {
       city.addTile(coords);
@@ -58,5 +63,33 @@ export class City {
 
   removeTile(coords: Coords) {
     this.tiles.delete(coords);
+  }
+
+  getUnits(): Unit[] {
+    return this.units;
+  }
+
+  getUnitPositions(): Coords[] {
+    return this.units.map(unit => unit.coords);
+  }
+
+  addUnit(unit: Unit): void {
+    this.units.push(unit);
+    if (this instanceof BarbarianCamp) {
+      unit.setBarbarian(true);
+    }
+  }
+
+  removeUnit(unit: Unit): void {
+    const unitIndex = this.units.indexOf(unit);
+    if (unitIndex > -1) {
+      this.units.splice(unitIndex, 1);
+    }
+  }
+}
+
+export class BarbarianCamp extends City {
+  constructor(center: Coords) {
+    super(center, 'camp', undefined)
   }
 }

--- a/src/server/game/map/tile/city.ts
+++ b/src/server/game/map/tile/city.ts
@@ -1,6 +1,6 @@
 import { Tile } from ".";
 import { Map } from "..";
-import { arrayIncludesCoords, getAdjacentCoords, getCoordInDirection, getDirection, getSmallesCoordsDiff, mod } from "../../../utils";
+import { arrayIncludesCoords, getAdjacentCoords, getCoordInDirection, getDirection, getSmallestCoordsDiff, mod } from "../../../utils";
 import { World, Coords } from "../../world";
 import { ErrandType } from "./errand";
 import { Improvement } from "./improvement";
@@ -302,7 +302,7 @@ export class BarbarianCamp extends UnitController {
       while (unit.movement > 0) {
         i++;
         const adjacentCoords = getAdjacentCoords(unit.coords);
-        const [targetXDiff, targetYDiff] = getSmallesCoordsDiff(map, unit.coords, currentTarget);
+        const [targetXDiff, targetYDiff] = getSmallestCoordsDiff(map, unit.coords, currentTarget);
 
         let directRoute: Coords | null = null;
         const altRoutes: Coords[] = [];

--- a/src/server/game/map/tile/city.ts
+++ b/src/server/game/map/tile/city.ts
@@ -1,7 +1,9 @@
 import { Tile } from ".";
 import { Map } from "..";
-import { getAdjacentCoords, getDirection, getSmallesCoordsDiff } from "../../../utils";
+import { arrayIncludesCoords, getAdjacentCoords, getCoordInDirection, getDirection, getSmallesCoordsDiff, mod } from "../../../utils";
 import { World, Coords } from "../../world";
+import { ErrandType } from "./errand";
+import { Improvement } from "./improvement";
 import { Unit } from "./unit";
 
 export interface CityData {
@@ -10,6 +12,7 @@ export interface CityData {
 }
 
 export class City {
+  id: number;
   center: Coords;
   name: string;
   civID?: number;
@@ -17,7 +20,8 @@ export class City {
 
   private tiles: Set<Coords>;
 
-  constructor(center: Coords, name: string, civID?: number) {
+  constructor(id: number, center: Coords, name: string, civID?: number) {
+    this.id = id;
     this.center = center;
     this.name = name;
     this.civID = civID;
@@ -124,19 +128,67 @@ export class UnitController extends City {
 }
 
 export class BarbarianCamp extends UnitController {
-  constructor(center: Coords) {
-    super(center, 'camp', undefined)
+  private raidTarget?: Coords;
+  private settleTarget?: Coords;
+
+  constructor(id: number, center: Coords) {
+    super(id, center, 'camp', undefined)
   }
 
   turn(world: World, map: Map): void {
     super.turn(world, map);
 
+    const camp = map.getTile(this.center).improvement as Improvement;
+    if (!camp.errand) {
+      let raidMode: boolean;
+      if (this.raidTarget && !this.settleTarget) {
+        raidMode = true;
+      } else if (!this.raidTarget && this.settleTarget) {
+        raidMode = false;
+      } else {
+        raidMode = Boolean(world.random.randInt(0, 1));
+      }
+      if (raidMode) {
+        // TODO
+      } else {
+        map.startErrandAt(this.center, camp, {
+          type: ErrandType.UNIT_TRAINING,
+          option: 'settler',
+          location: this.center,
+        });
+      }
+    }
+
     this.units.forEach(unit => {
       unit.newTurn();
 
       const visibleCoords = map.getVisibleTilesCoords(unit, unit.visionRange);
+      const canSeeCamp = arrayIncludesCoords(visibleCoords, this.center);
       if (unit.type === 'scout') {
-
+        if (!('turnsSinceCampSpotted' in unit.automationData)) {
+          unit.automationData.turnsSinceCampSpotted = 0;
+        }
+        unit.automationData.turnsSinceCampSpotted++;
+        visibleCoords.forEach(coords => {
+          const tile = map.getTile(coords);
+          if (tile.improvement) {
+            if (tile.improvement.type === 'barbarian_camp') {
+              unit.automationData.turnsSinceCampSpotted = 0;
+              if (!(coords.x === this.center.x && coords.y === this.center.y)) {
+                unit.automationData.target = this.center;
+                delete unit.automationData.wanderTarget;
+              } else if (unit.automationData.target) {
+                this.raidTarget = unit.automationData.raidTarget ?? this.raidTarget;
+                this.settleTarget = unit.automationData.settleTarget ?? this.settleTarget;
+              }
+            }
+          }
+          if (unit.automationData.turnsSinceCampSpotted > 3 && !canSeeCamp) {
+            if (map.canSettleOn(tile) && !unit.automationData.settleTarget) {
+              
+            }
+          }
+        });
       }
 
       if (!('wanderTarget' in unit.automationData)) {
@@ -145,9 +197,19 @@ export class BarbarianCamp extends UnitController {
           y: world.random.randInt(0, map.height - 1),
         };
       }
-      const currentTarget = unit.automationData.target ?? unit.automationData.wanderTarget;
+      if (
+        unit.automationData.target && (
+          (unit.coords.x === unit.automationData.target.x && unit.coords.y === unit.automationData.target.y) ||
+          arrayIncludesCoords(getAdjacentCoords(unit.coords), unit.automationData.target)
+        )
+      ) {
+        delete unit.automationData.target;
+      }
+      let currentTarget = unit.automationData.target ?? unit.automationData.wanderTarget;
       let stepsTaken = 0;
+      let i = 0;
       while (unit.movement > 0) {
+        i++;
         const adjacentCoords = getAdjacentCoords(unit.coords);
         const [targetXDiff, targetYDiff] = getSmallesCoordsDiff(map, unit.coords, currentTarget);
 
@@ -157,15 +219,21 @@ export class BarbarianCamp extends UnitController {
           const [xDiff, yDiff] = [coord.x - unit.coords.x, coord.y - unit.coords.y];
           if (Math.sign(targetXDiff) === xDiff && Math.sign(targetYDiff) === yDiff) {
             directRoute = coord;
-          } else if ((xDiff && Math.sign(targetXDiff) === xDiff) || (yDiff && Math.sign(targetYDiff) === yDiff)) {
+          } else if ((xDiff && !yDiff && Math.sign(targetXDiff) === xDiff) || (yDiff && !xDiff && Math.sign(targetYDiff) === yDiff)) {
             altRoutes.push(coord);
           }
+        }
+        if (!(directRoute || altRoutes.length > 0) || i > 100) {
+          console.warn(`Barbarian unit seems to be stuck at ${JSON.stringify(unit.coords)}. Skipping.`)
+          delete unit.automationData.wanderTarget;
+          break;
         }
 
         if (directRoute && map.areValidCoords(directRoute) && this.moveUnit(unit, directRoute)) {
           stepsTaken++;
           continue;
-        } else {
+        }
+        else {
           let didMove = false;
           for (const dst of altRoutes) {
             if (map.areValidCoords(dst) && this.moveUnit(unit, dst)) {
@@ -180,6 +248,10 @@ export class BarbarianCamp extends UnitController {
         }
 
         if (stepsTaken === 0) {
+          if (!(currentTarget.x === unit.automationData.wanderTarget.x && currentTarget.y === unit.automationData.wanderTarget.y)) {
+            currentTarget = unit.automationData.wanderTarget;
+            continue;
+          }
           // If there is no movement we can make towards our target, let switch to a new one.
           unit.automationData.wanderTarget = {
             x: world.random.randInt(0, map.width),

--- a/src/server/game/map/tile/city.ts
+++ b/src/server/game/map/tile/city.ts
@@ -1,3 +1,7 @@
+import { Tile } from ".";
+import { Map } from "..";
+import { getAdjacentCoords, getDirection, getSmallesCoordsDiff } from "../../../utils";
+import { World, Coords } from "../../world";
 import { Unit } from "./unit";
 
 export interface CityData {
@@ -86,10 +90,104 @@ export class City {
       this.units.splice(unitIndex, 1);
     }
   }
+
+  turn(world: World, map: Map): void {
+    // By default, do nothing (for now)
+  }
+
+
 }
 
-export class BarbarianCamp extends City {
+export class UnitController extends City {
+  private map: Map;
+
+  moveUnit(unit: Unit, toPos: Coords): boolean {
+    const tile = this.map.getTile(toPos);
+    if (!tile) return false;
+    const movementCost = tile.getMovementCost(unit, getDirection(toPos, unit.coords));
+    if (!(unit.movement < movementCost)) {
+      if (tile.unit) return false;
+      this.map.moveUnitTo(unit, toPos);
+      unit.movement -= movementCost;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  turn(world: World, map: Map): void {
+    super.turn(world, map);
+    if (!this.map) {
+      this.map = map;
+    }
+  }
+}
+
+export class BarbarianCamp extends UnitController {
   constructor(center: Coords) {
     super(center, 'camp', undefined)
+  }
+
+  turn(world: World, map: Map): void {
+    super.turn(world, map);
+
+    this.units.forEach(unit => {
+      unit.newTurn();
+
+      const visibleCoords = map.getVisibleTilesCoords(unit, unit.visionRange);
+      if (unit.type === 'scout') {
+
+      }
+
+      if (!('wanderTarget' in unit.automationData)) {
+        unit.automationData.wanderTarget = {
+          x: world.random.randInt(0, map.width - 1),
+          y: world.random.randInt(0, map.height - 1),
+        };
+      }
+      const currentTarget = unit.automationData.target ?? unit.automationData.wanderTarget;
+      let stepsTaken = 0;
+      while (unit.movement > 0) {
+        const adjacentCoords = getAdjacentCoords(unit.coords);
+        const [targetXDiff, targetYDiff] = getSmallesCoordsDiff(map, unit.coords, currentTarget);
+
+        let directRoute: Coords | null = null;
+        const altRoutes: Coords[] = [];
+        for (const coord of adjacentCoords) {
+          const [xDiff, yDiff] = [coord.x - unit.coords.x, coord.y - unit.coords.y];
+          if (Math.sign(targetXDiff) === xDiff && Math.sign(targetYDiff) === yDiff) {
+            directRoute = coord;
+          } else if ((xDiff && Math.sign(targetXDiff) === xDiff) || (yDiff && Math.sign(targetYDiff) === yDiff)) {
+            altRoutes.push(coord);
+          }
+        }
+
+        if (directRoute && map.areValidCoords(directRoute) && this.moveUnit(unit, directRoute)) {
+          stepsTaken++;
+          continue;
+        } else {
+          let didMove = false;
+          for (const dst of altRoutes) {
+            if (map.areValidCoords(dst) && this.moveUnit(unit, dst)) {
+              stepsTaken++;
+              didMove = true;
+              break;
+            }
+          }
+          if (didMove) {
+            continue;
+          }
+        }
+
+        if (stepsTaken === 0) {
+          // If there is no movement we can make towards our target, let switch to a new one.
+          unit.automationData.wanderTarget = {
+            x: world.random.randInt(0, map.width),
+            y: world.random.randInt(0, map.height),
+          };
+        }
+        break;
+      }
+    })
   }
 }

--- a/src/server/game/map/tile/errand.ts
+++ b/src/server/game/map/tile/errand.ts
@@ -44,7 +44,6 @@ export class WorkErrand {
       tile.improvement = new Improvement(action.option, tile.baseYield);
     },
     [ErrandType.UNIT_TRAINING]: (world, map, tile, action) => {
-      console.log(tile, action)
       if (!(tile.owner && action.location)) return;
       const newUnit = new Unit(action.option, action.location, tile.owner.civID, tile.owner.civID ? undefined : tile.owner.id);
       if (tile.unit) {

--- a/src/server/game/map/tile/errand.ts
+++ b/src/server/game/map/tile/errand.ts
@@ -44,6 +44,7 @@ export class WorkErrand {
       tile.improvement = new Improvement(action.option, tile.baseYield);
     },
     [ErrandType.UNIT_TRAINING]: (world, map, tile, action) => {
+      console.log(tile, action)
       if (!(tile.owner && action.location)) return;
       const newUnit = new Unit(action.option, action.location, tile.owner.civID, tile.owner.civID ? undefined : tile.owner.id);
       if (tile.unit) {

--- a/src/server/game/map/tile/errand.ts
+++ b/src/server/game/map/tile/errand.ts
@@ -45,7 +45,7 @@ export class WorkErrand {
     },
     [ErrandType.UNIT_TRAINING]: (world, map, tile, action) => {
       if (!(tile.owner && action.location)) return;
-      const newUnit = new Unit(action.option, action.location, tile.owner.civID);
+      const newUnit = new Unit(action.option, action.location, tile.owner.civID, tile.owner.civID ? undefined : tile.owner.id);
       if (tile.unit) {
         // if there is already a unit on this tile, we must figure something else out
       } else {

--- a/src/server/game/map/tile/errand.ts
+++ b/src/server/game/map/tile/errand.ts
@@ -45,7 +45,7 @@ export class WorkErrand {
     },
     [ErrandType.UNIT_TRAINING]: (world, map, tile, action) => {
       if (!(tile.owner && action.location)) return;
-      const newUnit = new Unit(action.option, tile.owner.civID, action.location);
+      const newUnit = new Unit(action.option, action.location, tile.owner.civID);
       if (tile.unit) {
         // if there is already a unit on this tile, we must figure something else out
       } else {

--- a/src/server/game/map/tile/improvement.ts
+++ b/src/server/game/map/tile/improvement.ts
@@ -23,6 +23,7 @@ export interface ImprovementConstructionCost {
 export class Improvement {
   static yieldTable: { [improvement: string]: Yield } = {
     'settlement': new Yield({food: 2, production: 2}),
+    'barbarian_camp': new Yield({food: 2, production: 2}),
     'encampment': new Yield({production: 1}),
     'campus': new Yield({science: 5}),
   
@@ -33,6 +34,7 @@ export class Improvement {
   
   static storeCapTable: { [improvement: string]: YieldParams } = {
     'settlement': {food: 20, production: 2},
+    'barbarian_camp': {food: 20, production: 2},
     'encampment': {food: 10, production: 1},
   
     'farm': {food: 20},

--- a/src/server/game/map/tile/unit.ts
+++ b/src/server/game/map/tile/unit.ts
@@ -139,6 +139,7 @@ export class Unit {
   isBarbarian?: boolean;
 
   public knowledge: KnowledgeMap;
+  public automationData: { [key: string]: any };
 
   static makeCatalog(types: string[]): UnitTypeCost[] {
     return types.map(type => (
@@ -162,6 +163,7 @@ export class Unit {
     this.coords = coords;
     this.alive = true;
     this.knowledge = knowledge ?? {};
+    this.automationData = {};
     if (Unit.cloakTable[type]) {
       this.cloaked = false;
     }

--- a/src/server/game/map/tile/unit.ts
+++ b/src/server/game/map/tile/unit.ts
@@ -12,11 +12,12 @@ export interface UnitData {
   type: string,
   hp: number,
   movement: number,
-  civID: number,
+  civID?: number,
   promotionClass: PromotionClass,
   attackRange?: number,
   knowledge: KnowledgeMap,
   cloaked?: boolean,
+  isBarbarian?: boolean,
 }
 
 export enum MovementClass {
@@ -130,10 +131,12 @@ export class Unit {
   combatStats: [number, number, number];
   attackRange?: number;
   visionRange: number;
-  civID: number;
+  civID?: number;
+  cityID?: number;
   coords: Coords;
   alive: boolean;
   cloaked?: boolean;
+  isBarbarian?: boolean;
 
   public knowledge: KnowledgeMap;
 
@@ -143,7 +146,7 @@ export class Unit {
     ));
   }
 
-  constructor(type: string, civID: number, coords: Coords, knowledge?: KnowledgeMap) {
+  constructor(type: string, coords: Coords, civID?: number, cityID?: number, knowledge?: KnowledgeMap) {
     this.type = type;
     this.hp = 100;
     this.movement = 0;
@@ -155,6 +158,7 @@ export class Unit {
     }
     this.visionRange = Unit.visionRangeTable[type] ?? Unit.visionRangeTable.default;
     this.civID = civID;
+    this.cityID = cityID;
     this.coords = coords;
     this.alive = true;
     this.knowledge = knowledge ?? {};
@@ -169,6 +173,7 @@ export class Unit {
       hp: this.hp,
       movement: this.movement,
       civID: this.civID,
+      cityID: this.cityID,
       coords: this.coords,
       alive: this.alive,
       knowledge: this.knowledge,
@@ -177,7 +182,7 @@ export class Unit {
   }
 
   static import(data: any): Unit {
-    const unit = new Unit(data.type, data.civID, data.coords);
+    const unit = new Unit(data.type, data.coords, data.civID, data.cityID, data.knowledge);
     unit.hp = data.hp;
     unit.movement = data.movement;
     unit.promotionClass = Unit.promotionClassTable[unit.type];
@@ -204,6 +209,7 @@ export class Unit {
       attackRange: this.attackRange,
       knowledge: this.knowledge,
       cloaked: this.cloaked,
+      isBarbarian: this.isBarbarian,
     } : undefined;
   }
   
@@ -213,6 +219,10 @@ export class Unit {
 
   setDead(): void {
     this.alive = false;
+  }
+
+  setBarbarian(isBarbarian: boolean): void {
+    this.isBarbarian = isBarbarian;
   }
 
   isDead(): boolean {

--- a/src/server/game/world.ts
+++ b/src/server/game/world.ts
@@ -40,8 +40,8 @@ export class World {
 
       this.getStartLocaltion(([settlerCoords, builderCoords, scoutCoords]) => {
         this.addUnit(new Unit('settler', settlerCoords, civID));
-        this.addUnit(new Unit('builder', builderCoords, civID));
-        this.addUnit(new Unit('scout', scoutCoords, civID));
+        // this.addUnit(new Unit('builder', builderCoords, civID));
+        // this.addUnit(new Unit('scout', scoutCoords, civID));
       });
 
       this.updateCivTileVisibility(civID);

--- a/src/server/game/world.ts
+++ b/src/server/game/world.ts
@@ -40,8 +40,8 @@ export class World {
 
       this.getStartLocaltion(([settlerCoords, builderCoords, scoutCoords]) => {
         this.addUnit(new Unit('settler', settlerCoords, civID));
-        // this.addUnit(new Unit('builder', builderCoords, civID));
-        // this.addUnit(new Unit('scout', scoutCoords, civID));
+        this.addUnit(new Unit('builder', builderCoords, civID));
+        this.addUnit(new Unit('scout', scoutCoords, civID));
       });
 
       this.updateCivTileVisibility(civID);

--- a/src/server/game/world.ts
+++ b/src/server/game/world.ts
@@ -40,14 +40,14 @@ export class World {
 
       this.getStartLocaltion(([settlerCoords, builderCoords, scoutCoords]) => {
         this.addUnit(new Unit('settler', settlerCoords, civID));
-        // this.addUnit(new Unit('builder', builderCoords, civID));
-        // this.addUnit(new Unit('scout', scoutCoords, civID));
+        this.addUnit(new Unit('builder', builderCoords, civID));
+        this.addUnit(new Unit('scout', scoutCoords, civID));
       });
 
       this.updateCivTileVisibility(civID);
     }
 
-    const barbarianTribes = 100; // Make this depend on map size
+    const barbarianTribes = 25; // Make this depend on map size
     for (let i = 0; i < barbarianTribes; i++) {
       this.getStartLocaltion(([settlerCoords, _, scoutCoords]) => {
         const cityID = this.map.newBarbarianCampAt(settlerCoords);

--- a/src/server/game/world.ts
+++ b/src/server/game/world.ts
@@ -36,39 +36,21 @@ export class World {
     for (let civID = 0; civID < this.civsCount; civID++) {
       this.civs[civID] = new Civilization();
 
-      const random = new Random(42);
-      let start_location_successful = false;
-      for (let i = 0; i < 1000; i++) {
-        const x = random.randInt(0, map.width-1);
-        const y = random.randInt(0, map.height-1);
-
-        const settler_coords = { x, y };
-        const builder_coords = { x: x + 1, y: y + 1 };
-        const   scout_coords = { x: x - 1, y: y + 1 };
-
-        let legal_start_location = true;
-        for (const coords of [settler_coords, builder_coords, scout_coords]) {
-          const tile = this.map.getTile(coords);
-          if (!tile || tile.unit || !this.map.canSettleOn(tile)) {
-            legal_start_location = false;
-            break;
-          }
-        }
-
-        if (legal_start_location) {
-          this.addUnit(new Unit('settler', civID, settler_coords));
-          this.addUnit(new Unit('builder', civID, builder_coords));
-          this.addUnit(new Unit('scout', civID, scout_coords));
-          start_location_successful = true;
-          break;
-        }
-      }
-
-      if (!start_location_successful) {
-        console.error("Error: couldn't find legal start location! (gave up after 1000 tries)");
-      }
+      this.getStartLocaltion(([settlerCoords, builderCoords, scoutCoords]) => {
+        this.addUnit(new Unit('settler', settlerCoords, civID));
+        this.addUnit(new Unit('builder', builderCoords, civID));
+        this.addUnit(new Unit('scout', scoutCoords, civID));
+      });
 
       this.updateCivTileVisibility(civID);
+    }
+
+    const barbarianTribes = 10; // Make this depend on map size
+    for (let i = 0; i < barbarianTribes; i++) {
+      this.getStartLocaltion(([settlerCoords, _, scoutCoords]) => {
+        const cityID = this.map.newBarbarianCampAt(settlerCoords);
+        if (cityID) this.addUnit(new Unit('scout', scoutCoords, undefined, cityID));
+      });
     }
 
     for (let i = 0; i < leaderTemplates.length; i++) {
@@ -79,6 +61,38 @@ export class World {
 
 
     // this.colorPool = colorList.reduce((obj: { [color: string]: boolean }, color: string) => ({...obj, [color]: true}), {});
+  }
+
+  getStartLocaltion(callback: (coords: [Coords, Coords, Coords]) => void): void {
+    const random = new Random(42);
+    let start_location_successful = false;
+    for (let i = 0; i < 1000; i++) {
+      const x = random.randInt(0, this.map.width-1);
+      const y = random.randInt(0, this.map.height-1);
+
+      const settlerCoords = { x, y };
+      const builderCoords = { x: x + 1, y: y + 1 };
+      const   scoutCoords = { x: x - 1, y: y + 1 };
+
+      let legal_start_location = true;
+      for (const coords of [settlerCoords, builderCoords, scoutCoords]) {
+        const tile = this.map.getTile(coords);
+        if (!tile || tile.unit || !this.map.canSettleOn(tile)) {
+          legal_start_location = false;
+          break;
+        }
+      }
+
+      if (legal_start_location) {
+        callback([settlerCoords, builderCoords, scoutCoords]);
+        start_location_successful = true;
+        break;
+      }
+    }
+
+    if (!start_location_successful) {
+      throw 'Error: couldn\'t find legal start location! (gave up after 1000 tries)';
+    }
   }
 
   export() {
@@ -221,18 +235,20 @@ export class World {
   // map, civs
   addUnit(unit: Unit): void {
     if (this.map.isInBounds(unit.coords)) {
-      this.civs[unit.civID].addUnit(unit);
+      if (unit.civID !== undefined) this.civs[unit.civID].addUnit(unit);
+      else if (unit.cityID !== undefined) this.map.cities[unit.cityID].addUnit(unit);
       this.map.getTile(unit.coords).setUnit(unit);
     }
   }
 
   // map, civs
   removeUnit(unit: Unit): void {
-    this.civs[unit.civID].removeUnit(unit);
+    if (unit.civID !== undefined) this.civs[unit.civID].removeUnit(unit);
+    else if (unit.cityID !== undefined) this.map.cities[unit.cityID].removeUnit(unit);
     this.updates.push(() => ['unitKilled', [ unit.coords, unit ]]);
     this.map.getTile(unit.coords).setUnit(undefined);
     // TODO: make this more intelligent
-    this.updateCivTileVisibility(unit.civID)
+    if (unit.civID !== undefined) this.updateCivTileVisibility(unit.civID)
     this.updates.push((civID) => ['setMap', [this.map.getCivMap(civID)]]);
   }
 

--- a/src/server/game/world.ts
+++ b/src/server/game/world.ts
@@ -47,11 +47,11 @@ export class World {
       this.updateCivTileVisibility(civID);
     }
 
-    const barbarianTribes = 25; // Make this depend on map size
+    const barbarianTribes = Math.ceil(map.height * map.width / 1500);
     for (let i = 0; i < barbarianTribes; i++) {
       this.getStartLocaltion(([settlerCoords, _, scoutCoords]) => {
         const cityID = this.map.newBarbarianCampAt(settlerCoords);
-        if (cityID) this.addUnit(new Unit('scout', scoutCoords, undefined, cityID));
+        if (cityID !== null) this.addUnit(new Unit('scout', scoutCoords, undefined, cityID));
       });
     }
 

--- a/src/server/game/world.ts
+++ b/src/server/game/world.ts
@@ -23,13 +23,12 @@ export class World {
   public currentTurn: number;
 
   constructor(map?: Map, civsCount?: number) {
-    this.random = new Random(42);
-
     this.updates = [];
 
     if (!(map && civsCount)) {
       return
     }
+    this.random = new Random(map.seed);
     this.map = map;
 
     this.civsCount = civsCount;

--- a/src/server/game/world.ts
+++ b/src/server/game/world.ts
@@ -18,10 +18,13 @@ export class World {
   civsCount: number;
   leaderPool: { [leaderID: number]: Leader };
   updates: { (civID: number): Event }[];
+  random: Random;
 
   public currentTurn: number;
 
   constructor(map?: Map, civsCount?: number) {
+    this.random = new Random(42);
+
     this.updates = [];
 
     if (!(map && civsCount)) {
@@ -64,11 +67,10 @@ export class World {
   }
 
   getStartLocaltion(callback: (coords: [Coords, Coords, Coords]) => void): void {
-    const random = new Random(42);
     let start_location_successful = false;
     for (let i = 0; i < 1000; i++) {
-      const x = random.randInt(0, this.map.width-1);
-      const y = random.randInt(0, this.map.height-1);
+      const x = this.random.randInt(0, this.map.width-1);
+      const y = this.random.randInt(0, this.map.height-1);
 
       const settlerCoords = { x, y };
       const builderCoords = { x: x + 1, y: y + 1 };

--- a/src/server/game/world.ts
+++ b/src/server/game/world.ts
@@ -40,14 +40,14 @@ export class World {
 
       this.getStartLocaltion(([settlerCoords, builderCoords, scoutCoords]) => {
         this.addUnit(new Unit('settler', settlerCoords, civID));
-        this.addUnit(new Unit('builder', builderCoords, civID));
-        this.addUnit(new Unit('scout', scoutCoords, civID));
+        // this.addUnit(new Unit('builder', builderCoords, civID));
+        // this.addUnit(new Unit('scout', scoutCoords, civID));
       });
 
       this.updateCivTileVisibility(civID);
     }
 
-    const barbarianTribes = 10; // Make this depend on map size
+    const barbarianTribes = 100; // Make this depend on map size
     for (let i = 0; i < barbarianTribes; i++) {
       this.getStartLocaltion(([settlerCoords, _, scoutCoords]) => {
         const cityID = this.map.newBarbarianCampAt(settlerCoords);
@@ -92,7 +92,11 @@ export class World {
     }
 
     if (!start_location_successful) {
-      throw 'Error: couldn\'t find legal start location! (gave up after 1000 tries)';
+      throw {
+        type: 'mapError',
+        code: 'noStartLocation',
+        msg: 'Error: couldn\'t find legal start location! (gave up after 1000 tries)',
+      };
     }
   }
 

--- a/src/server/utils/index.ts
+++ b/src/server/utils/index.ts
@@ -87,7 +87,7 @@ export const arrayIncludesCoords = (array: Coords[], {x, y}: Coords): boolean =>
   return false;
 };
 
-export const getSmallesCoordsDiff = (map: Map, pos: Coords, target: Coords): [number, number] => {
+export const getSmallestCoordsDiff = (map: Map, pos: Coords, target: Coords): [number, number] => {
   const { width } = map;
   const [posX, posY] = [mod(pos.x, width), pos.y];
   const [targetX, targetY] = [target.x, target.y];

--- a/src/server/utils/index.ts
+++ b/src/server/utils/index.ts
@@ -1,3 +1,4 @@
+import { Map } from '../game/map';
 import { Coords } from '../game/world';
 
 export type Event = [string, unknown[]];
@@ -77,11 +78,21 @@ export const getDirection = (origin: Coords, target: Coords): number => {
   });
 
   return direction;
-}
+};
 
 export const arrayIncludesCoords = (array: Coords[], {x, y}: Coords): boolean => {
   for (const coords of array) {
     if (coords.x === x && coords.y === y) return true;
   }
   return false;
+};
+
+export const getSmallesCoordsDiff = (map: Map, pos: Coords, target: Coords): [number, number] => {
+  const { width } = map;
+  const [posX, posY] = [mod(pos.x, width), pos.y];
+  const [targetX, targetY] = [target.x, target.y];
+  const altTargetX = targetX < posX ? (targetX + width) : (targetX - width);
+  const xDiff = targetX - posX;
+  const altXDiff = altTargetX - posX;
+  return [(Math.abs(xDiff) <= Math.abs(altXDiff)) ? (xDiff) : (altXDiff), targetY - posY];
 };


### PR DESCRIPTION
closes #163; addresses the backend half of #114

- Add Barbarian camps, that spawn barbarian units
- Barbarian scouts wander around, currently only really to look for settling sites
- Barbarian settlers create new camps
- Barbarian warriors currently only protect the area around their camp
- If game fails to start due to no start location being found, the game will try to re-generate the map up to 10 times
- Units can now belong to a city instead of a civ. _They should never belong to both!_